### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/crate/pulldown-cmark-to-cmark"
 readme = "README.md"
 
 [dependencies]
-pulldown-cmark = {version = "0.1.0", default-features = false}
+pulldown-cmark = {version = "0.2.0", default-features = false}
 
 [dev-dependencies]
-indoc = "0.2.3"
+indoc = "0.3.1"


### PR DESCRIPTION
Since this crate uses the `Event` type from pulldown-cmark in it's API, it has to stay up-to-date with the pulldown-cmark version, to prevent version mismatch.