### PR TITLE
Pulldown cmark 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/crate/pulldown-cmark-to-cmark"
 readme = "README.md"
 
 [dependencies]
-pulldown-cmark = {version = "0.2.0", default-features = false}
+pulldown-cmark = {version = "0.4.1", default-features = false}
 
 [dev-dependencies]
 indoc = "0.3.1"

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -12,6 +12,7 @@ fn s(e: Event) -> String {
 
 mod start {
     use pulldown_cmark::Event::*;
+    use pulldown_cmark::LinkType::*;
     use pulldown_cmark::Tag::*;
     use pulldown_cmark::Alignment::{self, Center, Left, Right};
     use super::s;
@@ -70,19 +71,19 @@ mod start {
     }
     #[test]
     fn link() {
-        assert_eq!(s(Start(Link("uri".into(), "title".into()))), "[")
+        assert_eq!(s(Start(Link(Inline, "uri".into(), "title".into()))), "[")
     }
     #[test]
     fn link_without_title() {
-        assert_eq!(s(Start(Link("uri".into(), "".into()))), "[")
+        assert_eq!(s(Start(Link(Inline, "uri".into(), "".into()))), "[")
     }
     #[test]
     fn image() {
-        assert_eq!(s(Start(Image("uri".into(), "title".into()))), "![")
+        assert_eq!(s(Start(Image(Inline, "uri".into(), "title".into()))), "![")
     }
     #[test]
     fn image_without_title() {
-        assert_eq!(s(Start(Image("uri".into(), "".into()))), "![")
+        assert_eq!(s(Start(Image(Inline, "uri".into(), "".into()))), "![")
     }
     #[test]
     fn table() {
@@ -107,6 +108,7 @@ mod start {
 
 mod end {
     use pulldown_cmark::Event::*;
+    use pulldown_cmark::LinkType::*;
     use pulldown_cmark::Tag::*;
     use pulldown_cmark::Alignment::{self, Center, Left, Right};
     use super::s;
@@ -162,24 +164,24 @@ mod end {
     #[test]
     fn link() {
         assert_eq!(
-            s(End(Link("/uri".into(), "title".into()))),
+            s(End(Link(Inline, "/uri".into(), "title".into()))),
             "](/uri \"title\")"
         )
     }
     #[test]
     fn link_without_title() {
-        assert_eq!(s(End(Link("/uri".into(), "".into()))), "](/uri)")
+        assert_eq!(s(End(Link(Inline, "/uri".into(), "".into()))), "](/uri)")
     }
     #[test]
     fn image() {
         assert_eq!(
-            s(End(Image("/uri".into(), "title".into()))),
+            s(End(Image(Inline, "/uri".into(), "title".into()))),
             "](/uri \"title\")"
         )
     }
     #[test]
     fn image_without_title() {
-        assert_eq!(s(End(Image("/uri".into(), "".into()))), "](/uri)")
+        assert_eq!(s(End(Image(Inline, "/uri".into(), "".into()))), "](/uri)")
     }
     #[test]
     fn table() {

--- a/tests/fixtures/snapshots/stupicat-table-output
+++ b/tests/fixtures/snapshots/stupicat-table-output
@@ -1,26 +1,26 @@
 Colons can be used to align columns.
 
-| Tables        | Are           | Cool  | yo |
-|---------------|:-------------:|------:|:---|
-| col 3 is      | right-aligned | $1600 | x  |
-| col 2 is      | centered      |   $12 | y  |
-| zebra stripes | are neat      |    $1 | z  |
+|Tables        |Are           |Cool  |yo |
+|--------------|:------------:|-----:|:--|
+|col 3 is      |right-aligned |$1600 |x  |
+|col 2 is      |centered      |$12 |y  |
+|zebra stripes |are neat      |$1 |z  |
 
 There must be at least 3 dashes separating each header cell.
 The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
  > 
- > |Markdown | Less | Pretty|
- > |---------|------|-------|
- > |*Still* | `renders` | **nicely**|
- > |1 | 2 | 3|
+ > |Markdown |Less |Pretty|
+ > |---------|-----|------|
+ > |*Still* |`renders` |**nicely**|
+ > |1 |2 |3|
 
-|  Target                       | std |rustc|cargo| notes                      |
-|-------------------------------|-----|-----|-----|----------------------------|
-| `x86_64-unknown-linux-musl`   |  ✓  |     |     | 64-bit Linux with MUSL     |
-| `arm-linux-androideabi`       |  ✓  |     |     | ARM Android                |
-| `arm-unknown-linux-gnueabi`   |  ✓  |  ✓  |     | ARM Linux (2.6.18+)        |
-| `arm-unknown-linux-gnueabihf` |  ✓  |  ✓  |     | ARM Linux (2.6.18+)        |
-| `aarch64-unknown-linux-gnu`   |  ✓  |     |     | ARM64 Linux (2.6.18+)      |
-| `mips-unknown-linux-gnu`      |  ✓  |     |     | MIPS Linux (2.6.18+)       |
-| `mipsel-unknown-linux-gnu`    |  ✓  |     |     | MIPS (LE) Linux (2.6.18+)  |
+|Target                       |std |rustc|cargo|notes                      |
+|-----------------------------|----|-----|-----|---------------------------|
+|`x86_64-unknown-linux-musl`   |✓  |||64-bit Linux with MUSL     |
+|`arm-linux-androideabi`       |✓  |||ARM Android                |
+|`arm-unknown-linux-gnueabi`   |✓  |✓  ||ARM Linux (2.6.18+)        |
+|`arm-unknown-linux-gnueabihf` |✓  |✓  ||ARM Linux (2.6.18+)        |
+|`aarch64-unknown-linux-gnu`   |✓  |||ARM64 Linux (2.6.18+)      |
+|`mips-unknown-linux-gnu`      |✓  |||MIPS Linux (2.6.18+)       |
+|`mipsel-unknown-linux-gnu`    |✓  |||MIPS (LE) Linux (2.6.18+)  |

--- a/tests/fixtures/table.md
+++ b/tests/fixtures/table.md
@@ -4,17 +4,17 @@ Colons can be used to align columns.
 |---------------|:-------------:|------:|:---|
 | col 3 is      | right-aligned | $1600 | x  |
 | col 2 is      | centered      |   $12 | y  |
-| zebra stripes | are neat      |    $1 | z  | 
+| zebra stripes | are neat      |    $1 | z  |
 
 There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the 
+The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
 
  > Markdown | Less | Pretty
  > --- | --- | ---
  > *Still* | `renders` | **nicely**
  > 1 | 2 | 3
- 
+
 |  Target                       | std |rustc|cargo| notes                      |
 |-------------------------------|-----|-----|-----|----------------------------|
 | `x86_64-unknown-linux-musl`   |  ✓  |     |     | 64-bit Linux with MUSL     |

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -424,6 +424,35 @@ mod table {
             }
         )
     }
+    #[test]
+    fn it_generates_equivalent_table_markdown() {
+        use pulldown_cmark::{Options, Parser};
+
+        let original_table_markdown = indoc!(
+            "
+            | Tables        | Are           | Cool  | yo |
+            |---------------|:-------------:|------:|:---|
+            | col 3 is      | right-aligned | $1600 | x  |
+            | col 2 is      | centered      |   $12 | y  |
+            | zebra stripes | are neat      |    $1 | z  |"
+        );
+        let p = Parser::new_ext(original_table_markdown, Options::all());
+        let original_events: Vec<_> = p.into_iter().collect();
+
+        let (generated_markdown, _) = fmte(&original_events);
+
+        assert_eq!(generated_markdown, indoc!("
+            |Tables        |Are           |Cool  |yo |
+            |--------------|:------------:|-----:|:--|
+            |col 3 is      |right-aligned |$1600 |x  |
+            |col 2 is      |centered      |$12 |y  |
+            |zebra stripes |are neat      |$1 |z  |"));
+
+        let p = Parser::new_ext(&generated_markdown, Options::all());
+        let generated_events: Vec<_> = p.into_iter().collect();
+
+        assert_eq!(original_events, generated_events);
+    }
 }
 
 mod list {

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -4,7 +4,7 @@ extern crate pulldown_cmark;
 extern crate pulldown_cmark_to_cmark;
 
 use pulldown_cmark_to_cmark::fmt::{cmark, State};
-use pulldown_cmark::{Alignment, Event, Options, Parser, Tag};
+use pulldown_cmark::{Alignment, Event, LinkType, Options, Parser, Tag};
 
 fn fmts(s: &str) -> (String, State<'static>) {
     let mut buf = String::new();
@@ -26,7 +26,7 @@ fn fmte(e: &[Event]) -> (String, State<'static>) {
 
 mod lazy_newlines {
     use super::{fmte, fmts};
-    use super::{Event, State, Tag};
+    use super::{Event, LinkType, State, Tag};
 
     #[test]
     fn after_emphasis_there_is_no_newline() {
@@ -35,8 +35,8 @@ mod lazy_newlines {
             Tag::Strong,
             Tag::Code,
             Tag::BlockQuote,
-            Tag::Link("".into(), "".into()),
-            Tag::Image("".into(), "".into()),
+            Tag::Link(LinkType::Inline, "".into(), "".into()),
+            Tag::Image(LinkType::Inline, "".into(), "".into()),
             Tag::FootnoteDefinition("".into()),
         ] {
             assert_eq!(
@@ -107,7 +107,11 @@ fn it_applies_newlines_before_start_before_text() {
 fn it_applies_newlines_before_start_before_html_and_enforces_newline_after() {
     assert_eq!(
         fmtes(
-            &[Event::Html("<e>".into())],
+            &[
+                Event::Start(Tag::HtmlBlock),
+                Event::Html("<e>".into()),
+                Event::End(Tag::HtmlBlock),
+            ],
             State {
                 newlines_before_start: 2,
                 ..Default::default()
@@ -229,6 +233,14 @@ mod inline_elements {
                 }
             )
         )
+    }
+
+    #[test]
+    fn strikethrough() {
+        assert_eq!(
+            fmts("~~strikethrough~~").0,
+            "~~strikethrough~~",
+        );
     }
 }
 
@@ -507,5 +519,19 @@ mod list {
                 }
             )
         )
+    }
+
+    #[test]
+    fn checkboxes() {
+        assert_eq!(
+            fmts(indoc!(
+                "
+            * [ ] foo
+            * [x] bar
+            "
+            )).0,
+            "* [ ] foo\n* [x] bar",
+        );
+
     }
 }


### PR DESCRIPTION
This builds on @euclio's work in https://github.com/Byron/pulldown-cmark-to-cmark/pull/2 and I think gets all the tests passing 🤞 

I had to change the fixtures and the snapshots though, see the commit messages for details.

@ehuss this is probably relevant to your interests too :)