### PR TITLE
Better support for blockquotes (#6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pulldown-cmark-to-cmark"
 version = "1.2.3"
-authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+authors = ["Sebastian Thiel <byronimo@gmail.com>", "Dylan Owen <dyltotheo@gmail.com>"]
 
 description = "Convert pulldown-cmark Events back to the string they were parsed from"
 license = "Apache-2.0"

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -44,7 +44,7 @@ mod start {
     }
     #[test]
     fn blockquote() {
-        assert_eq!(s(Start(BlockQuote)), " > ")
+        assert_eq!(s(Start(BlockQuote)), "\n > ")
     }
     #[test]
     fn codeblock() {

--- a/tests/fixtures/snapshots/stupicat-ordered-output
+++ b/tests/fixtures/snapshots/stupicat-ordered-output
@@ -12,6 +12,7 @@ Ordered lists:
    1. With
       
       Paragraphs and nested blocks:
+      
        > 
        > A quote
    

--- a/tests/fixtures/snapshots/stupicat-output
+++ b/tests/fixtures/snapshots/stupicat-output
@@ -48,6 +48,7 @@ Unordered lists:
   * With
     
     Paragraphs and nested blocks:
+    
      > 
      > A quote
     
@@ -93,6 +94,7 @@ And a mix of both:
 ## Block level elements
 
 Block quotes
+
  > 
  > Lorem ipsum dolor sit amet, *consetetur sadipscing elitr*, sed diam nonumy
  > eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam

--- a/tests/fixtures/snapshots/stupicat-table-output
+++ b/tests/fixtures/snapshots/stupicat-table-output
@@ -9,6 +9,7 @@ Colons can be used to align columns.
 There must be at least 3 dashes separating each header cell.
 The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
+
  > 
  > |Markdown|Less|Pretty|
  > |--------|----|------|

--- a/tests/fixtures/snapshots/stupicat-unordered-output
+++ b/tests/fixtures/snapshots/stupicat-unordered-output
@@ -10,6 +10,7 @@ Unordered lists:
   * With
     
     Paragraphs and nested blocks:
+    
      > 
      > A quote
     

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -319,6 +319,21 @@ mod blockquote {
             " > a\n >  > \n >  > b\n > \n > c",
         )
     }
+
+    #[test]
+    fn initially_nested() {
+        assert_eq!(
+            fmts(indoc!(
+                "
+             > > foo
+             > bar
+             > > baz
+            "
+            ))
+                .0,
+            " >  > foo\n >  > bar\n >  > baz",
+        )
+    }
     #[test]
     fn simple() {
         assert_eq!(
@@ -330,6 +345,25 @@ mod blockquote {
             )),
             (
                 " > a\n > b  \n > c".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn with_blank_line() {
+        assert_eq!(
+            fmts(indoc!(
+                "
+                > foo
+
+                > bar"
+            )),
+            (
+                " > foo\n\n > bar".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -25,6 +25,19 @@ fn fmte(e: &[Event]) -> (String, State<'static>) {
     (buf, s)
 }
 
+/// Asserts that if we parse our `str` s into a series of events, then serialize them with `cmark`
+/// that we'll get the same series of events when we parse them again.
+fn assert_events_eq(s: &str) {
+    let before_events = Parser::new_ext(s, Options::all());
+
+    let mut buf = String::new();
+    cmark(before_events.clone(), &mut buf, None).unwrap();
+
+    let after_events = Parser::new_ext(&buf, Options::all());
+    println!("{}", buf);
+    assert_eq!(before_events.collect::<Vec<_>>(), after_events.collect::<Vec<_>>());
+}
+
 mod lazy_newlines {
     use super::{fmte, fmts};
     use super::{Event, LinkType, State, Tag};
@@ -34,7 +47,6 @@ mod lazy_newlines {
         for t in &[
             Tag::Emphasis,
             Tag::Strong,
-            Tag::BlockQuote,
             Tag::Link(LinkType::Inline, "".into(), "".into()),
             Tag::Image(LinkType::Inline, "".into(), "".into()),
             Tag::FootnoteDefinition("".into()),
@@ -243,6 +255,7 @@ mod inline_elements {
 
 mod blockquote {
     use super::{fmte, fmtes, fmts, Event, State, Tag};
+    use assert_events_eq;
 
     #[test]
     fn it_pops_padding_on_quote_end() {
@@ -256,6 +269,7 @@ mod blockquote {
             )
             .1,
             State {
+                newlines_before_start: 2,
                 padding: vec![],
                 ..Default::default()
             }
@@ -267,6 +281,7 @@ mod blockquote {
         assert_eq!(
             fmte(&[Event::Start(Tag::BlockQuote),]).1,
             State {
+                newlines_before_start: 1,
                 padding: vec![" > ".into()],
                 ..Default::default()
             }
@@ -275,76 +290,108 @@ mod blockquote {
 
     #[test]
     fn with_html() {
+        let s = indoc!("
+             > <table>
+             > </table>
+             ");
+
+        assert_events_eq(s);
+
         assert_eq!(
-            fmts(indoc!(
-                "
-         > <table>
-         > </table>"
-            ))
+            fmts(s)
             .0,
-            " > <table>\n > </table>",
+            "\n > \n > <table>\n > </table>\n > ",
         )
     }
     #[test]
     fn with_inlinehtml() {
-        assert_eq!(fmts(" > <br>").0, " > <br>",)
+        assert_eq!(fmts(" > <br>").0, "\n > \n > <br>")
     }
     #[test]
     fn with_codeblock() {
-        assert_eq!(
-            fmts(indoc!(
-                "
+        let s = indoc!("
              > ```a
              > t1
              > t2
              > ```
-            "
-            ))
+            ");
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s)
             .0,
-            " > ````a\n > t1\n > t2\n > ````",
+            "\n > \n > ````a\n > t1\n > t2\n > ````",
         )
     }
     #[test]
     fn nested() {
-        assert_eq!(
-            fmts(indoc!(
-                "
+        let s = indoc!("
              > a
+             >
              > > b
              >
              > c
-            "
-            ))
+            ");
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s)
             .0,
-            " > a\n >  > \n >  > b\n > \n > c",
+            "\n > \n > a\n > \n >  > \n >  > b\n > \n > c",
         )
     }
 
     #[test]
     fn initially_nested() {
-        assert_eq!(
-            fmts(indoc!(
-                "
+        let s = indoc!("
              > > foo
              > bar
              > > baz
-            "
-            ))
+            ");
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s)
                 .0,
-            " >  > foo\n >  > bar\n >  > baz",
+            "\n > \n >  > \n >  > foo\n >  > bar\n >  > baz",
         )
     }
+
     #[test]
     fn simple() {
-        assert_eq!(
-            fmts(indoc!(
-                "
+        let s = indoc!("
              > a
              > b  
-             > c"
-            )),
+             > c
+             ");
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s),
             (
-                " > a\n > b  \n > c".into(),
+                "\n > \n > a\n > b  \n > c".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn empty() {
+        let s = " > ";
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s),
+            (
+                "\n > ".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()
@@ -355,21 +402,107 @@ mod blockquote {
 
     #[test]
     fn with_blank_line() {
-        assert_eq!(
-            fmts(indoc!(
-                "
-                > foo
+        let s = indoc!("
+            > foo
 
-                > bar"
-            )),
+            > bar
+            ");
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s),
             (
-                " > foo\n\n > bar".into(),
+                "\n > \n > foo\n\n > \n > bar".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()
                 }
             )
         )
+    }
+
+    #[test]
+    fn with_lazy_continuation() {
+        let s = indoc!("
+            > foo
+            baz
+
+            > bar
+            ");
+
+        assert_events_eq(s);
+
+
+        assert_eq!(
+            fmts(s),
+            (
+                "\n > \n > foo\n > baz\n\n > \n > bar".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn with_lists() {
+        let s = indoc!("
+            - > * foo
+              >     * baz
+                - > bar
+            ");
+
+        assert_events_eq(s);
+
+        assert_eq!(
+            fmts(s),
+            (
+                "* \n   > \n   > * foo\n   >   * baz\n  \n  * \n     > \n     > bar".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn complex_nesting() {
+        assert_events_eq(indoc!(
+            "
+            > one
+            > > two
+            > > three
+            > four
+            >
+            > > five
+            >
+            > > six
+            > seven
+            > > > eight
+            nine
+
+            > ten
+
+            >
+
+            >
+            > >
+
+
+            > >
+            
+            > - eleven
+            >    - twelve
+            > > thirteen
+            > -
+            
+            - > fourteen
+                - > fifteen
+            "
+        ));
     }
 }
 


### PR DESCRIPTION
This is my initial attempt at fixing #6 . It makes some changes in the way we serialize blockquotes, so I opted to do most of my testing by verifying that the pulldown-cmark events line up before and after serializing.

Example differences 
```
> blockquote
```
is now serialized as
```
> 
> blockquote
```

this makes it easier to cover the edge case of an empty blockquote, without needing to preserve blockquote state across the events. 