### PR TITLE
Add newlines after HTML elemets if followed by more markdown

### DIFF
--- a/tests/cat.sh
+++ b/tests/cat.sh
@@ -38,3 +38,9 @@ title "stupicat"
     expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/common-mark.md 2>/dev/null"
 )
 
+
+(with "markdown and html nested"
+  it "succeeds" && \
+    WITH_SNAPSHOT="$snapshot/stupicat-nested-output" \
+    expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/nested.md 2>/dev/null"
+)

--- a/tests/fixtures/nested.md
+++ b/tests/fixtures/nested.md
@@ -1,0 +1,11 @@
+<div>
+
+*emphasized*
+
+</div>
+
+<div>
+second line
+</div>
+
+inline <abbr>html</abbr> element

--- a/tests/fixtures/snapshots/stupicat-nested-output
+++ b/tests/fixtures/snapshots/stupicat-nested-output
@@ -1,0 +1,10 @@
+<div>
+
+*emphasized*
+
+</div>
+<div>
+second line
+</div>
+
+inline <abbr>html</abbr> element

--- a/tests/fixtures/snapshots/stupicat-output
+++ b/tests/fixtures/snapshots/stupicat-output
@@ -155,6 +155,7 @@ vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
 no sea takimata sanctus est Lorem ipsum dolor sit amet.
 </p>
 </div>
+
 Or inline HTML, as in this paragraph: Lorem ipsum dolor sit amet, consetetur
 sadipscing elitr, sed <abbr>diam</abbr> nonumy eirmod tempor invidunt ut labore
 et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -217,7 +217,7 @@ mod inline_elements {
         assert_eq!(
             fmts("*a* b **c**\n<br>\nd\n\ne `c`"),
             (
-                "*a* b **c**\n<br>\nd\n\ne `c`".into(),
+                "*a* b **c**\n<br>\n\nd\n\ne `c`".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()
@@ -277,11 +277,19 @@ mod blockquote {
 
         assert_events_eq(s);
 
-        assert_eq!(fmts(s).0, "\n > \n > <table>\n > </table>\n > ",)
+        assert_eq!(fmts(s).0, "\n > \n > <table>\n > </table>\n > \n")
     }
     #[test]
     fn with_inlinehtml() {
-        assert_eq!(fmts(" > <br>").0, "\n > \n > <br>")
+        assert_eq!(fmts(" > <br>").0, "\n > \n > <br>\n")
+    }
+    #[test]
+    fn with_plaintext_in_html() {
+        assert_eq!(fmts("<del>\n*foo*\n</del>").0, "<del>\n*foo*\n</del>")
+    }
+    #[test]
+    fn with_markdown_nested_in_html() {
+        assert_eq!(fmts("<del>\n\n*foo*\n\n</del>").0, "<del>\n\n*foo*\n\n</del>")
     }
     #[test]
     fn with_codeblock() {


### PR DESCRIPTION
Markdown allows for HTML elements, into which further markdown formatting is nested.
However only if the HTML element is spaced by an additional newline.

Relevant spec: https://spec.commonmark.org/0.28/#html-blocks

Fixes #10

---

So I came up with this solution, which is everything but pretty.
The only way I could make it work is by keeping state if we've seen an HTML element and are followed by a markdown element next.
This might actually add unecessary newlines, but _I think_ it should produce HTML that renders the same. I might be wrong and in certain circumstances that newline might cause different rendering though.

To make it short: it fixes my specific problem, but might cause others. 