### PR TITLE
Add a newline before code blocks if necessary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,11 +295,18 @@ where
                     }
                     CodeBlock(CodeBlockKind::Fenced(ref info)) => {
                         state.is_in_code_block = true;
-                        formatter
-                            .write_str("````")
-                            .and(formatter.write_str(info))
-                            .and(formatter.write_char('\n'))
-                            .and(padding(&mut formatter, &state.padding))
+                        let s = if !consumed_newlines {
+                            formatter
+                                .write_char('\n')
+                                .and_then(|_| padding(&mut formatter, &state.padding))
+                        } else {
+                            Ok(())
+                        };
+
+                        s.and_then(|_| formatter.write_str("````"))
+                            .and_then(|_| formatter.write_str(info))
+                            .and_then(|_| formatter.write_char('\n'))
+                            .and_then(|_| padding(&mut formatter, &state.padding))
                     }
                     List(_) => Ok(()),
                     Strikethrough => formatter.write_str("~~"),

--- a/tests/cat.sh
+++ b/tests/cat.sh
@@ -38,9 +38,14 @@ title "stupicat"
     expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/common-mark.md 2>/dev/null"
 )
 
-
 (with "markdown and html nested"
   it "succeeds" && \
     WITH_SNAPSHOT="$snapshot/stupicat-nested-output" \
     expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/nested.md 2>/dev/null"
+)
+
+(with "lists and nested content"
+  it "succeeds" && \
+    WITH_SNAPSHOT="$snapshot/stupicat-lists-nested-output" \
+    expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/lists-nested.md 2>/dev/null"
 )

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -54,7 +54,7 @@ mod start {
     fn codeblock() {
         assert_eq!(
             s(Start(CodeBlock(CodeBlockKind::Fenced("asdf".into())))),
-            "````asdf\n"
+            "\n````asdf\n"
         )
     }
     #[test]

--- a/tests/fixtures/lists-nested.md
+++ b/tests/fixtures/lists-nested.md
@@ -1,0 +1,22 @@
+1. list paragraph 1
+   ```
+   code sample
+   ```
+2. list paragraph 2
+
+---
+
+1. list paragraph 1
+   ```
+   code sample
+   ```
+
+2. list paragraph 2
+
+---
+
+1. list paragraph 1
+
+       code sample
+
+2. list paragraph 2

--- a/tests/fixtures/snapshots/stupicat-lists-nested-output
+++ b/tests/fixtures/snapshots/stupicat-lists-nested-output
@@ -1,0 +1,26 @@
+1. list paragraph 1
+   ````
+   code sample
+   ````
+
+1. list paragraph 2
+
+---
+
+1. list paragraph 1
+   
+   ````
+   code sample
+   ````
+
+1. list paragraph 2
+
+---
+
+1. list paragraph 1
+   
+   ````
+   code sample
+   ````
+
+1. list paragraph 2

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -80,7 +80,7 @@ mod lazy_newlines {
 
     #[test]
     fn after_some_types_it_has_multiple_newlines() {
-        for md in &["paragraph", "## headline", "````\n````", "---"] {
+        for md in &["paragraph", "## headline", "\n````\n````", "---"] {
             assert_eq!(
                 fmts(md),
                 (
@@ -513,7 +513,7 @@ mod codeblock {
         assert_eq!(
             fmts("````hi\nsome\ntext\n````\na"),
             (
-                "````hi\nsome\ntext\n````\n\na".into(),
+                "\n````hi\nsome\ntext\n````\n\na".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()
@@ -526,7 +526,7 @@ mod codeblock {
         assert_eq!(
             fmts("```\n```"),
             (
-                "````\n````".into(),
+                "\n````\n````".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()
@@ -539,7 +539,7 @@ mod codeblock {
         assert_eq!(
             fmts("```hi\nsome\ntext\n```"),
             (
-                "````hi\nsome\ntext\n````".into(),
+                "\n````hi\nsome\ntext\n````".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()


### PR DESCRIPTION
Fixes #12

At least the prepending of newline.
The trailing ~~one~~ two newlines of a code block are at least configurable, so I can fix that in my usage. 
That means it's still not a _proper_ roundtrip from markdown to markdown, but fixing that is probably a bit more involved and requires touching a couple more tests.