### PR TITLE
Include code in table header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,10 +220,17 @@ where
                 }
                 formatter.write_str("---")
             }
-            Code(ref text) => formatter
-                .write_char('`')
-                .and_then(|_| formatter.write_str(text))
-                .and_then(|_| formatter.write_char('`')),
+            Code(ref text) => {
+                if state.store_next_text {
+                    state.store_next_text = false;
+                    let code = format!("`{}`", text);
+                    state.text_for_header = Some(code)
+                }
+                formatter
+                    .write_char('`')
+                    .and_then(|_| formatter.write_str(text))
+                    .and_then(|_| formatter.write_char('`'))
+            }
             Start(ref tag) => {
                 match *tag {
                     List(ref list_type) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ where
                             formatter.write_char('|')?;
                             // NOTE: For perfect counting, count grapheme clusters.
                             // The reason this is not done is to avoid the dependency.
-                            let last_minus_one = name.chars().count() - 1;
+                            let last_minus_one = name.chars().count().saturating_sub(1);
                             for c in 0..name.len() {
                                 formatter.write_char(
                                     if (c == 0

--- a/tests/fixtures/snapshots/stupicat-table-output
+++ b/tests/fixtures/snapshots/stupicat-table-output
@@ -25,3 +25,9 @@ raw Markdown line up prettily. You can also use inline Markdown.
 |`aarch64-unknown-linux-gnu`|✓|||ARM64 Linux (2.6.18+)|
 |`mips-unknown-linux-gnu`|✓|||MIPS Linux (2.6.18+)|
 |`mipsel-unknown-linux-gnu`|✓|||MIPS (LE) Linux (2.6.18+)|
+
+Tables with formatting in header
+
+|header|`code`|*emphasize*|*strong*|
+|------|------|---------|------|
+|data 1|data 2|data 3|data 4|

--- a/tests/fixtures/table.md
+++ b/tests/fixtures/table.md
@@ -24,3 +24,9 @@ raw Markdown line up prettily. You can also use inline Markdown.
 | `aarch64-unknown-linux-gnu`   |  ✓  |     |     | ARM64 Linux (2.6.18+)      |
 | `mips-unknown-linux-gnu`      |  ✓  |     |     | MIPS Linux (2.6.18+)       |
 | `mipsel-unknown-linux-gnu`    |  ✓  |     |     | MIPS (LE) Linux (2.6.18+)  |
+
+Tables with formatting in header
+
+| header | `code` | _emphasize_ | *strong* |
+| ------ | ------ | ----------- | -------- |
+| data 1 | data 2 | data 3      | data 4   |


### PR DESCRIPTION
On some of our markdown we faced the following panic:

```
thread 'main' panicked at 'attempt to subtract with overflow', pulldown-cmark-to-cmark/src/lib.rs:382:50
```

It contained inline code in a table header, which the parser failed to collect and thus leading to a subtraction underflow when calculating the table header.
This is fixed in the first commit.

As a defensive mechanism I also swapped it to just saturate at 0.
This should still produce valid markdown tables, just won't be perfectly nice formatted (but then again they already miss accounting for emphasis (`_`) or strong formatting, so it's off-by-2 in those cases) 