### PR TITLE
Don't add a newline after an HTML block if we're just ending another tag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ where
             match event {
                 Html(_) => { /* no newlines if HTML continues */ }
                 Text(_) => { /* no newlines for inline HTML */ }
+                End(_) => { /* no newlines if ending a previous opened tag */ }
                 _ => {
                     // Ensure next Markdown block is rendered properly
                     // by adding a newline after an HTML element.

--- a/tests/cat.sh
+++ b/tests/cat.sh
@@ -49,3 +49,9 @@ title "stupicat"
     WITH_SNAPSHOT="$snapshot/stupicat-lists-nested-output" \
     expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/lists-nested.md 2>/dev/null"
 )
+
+(with "table with html"
+  it "succeeds" && \
+    WITH_SNAPSHOT="$snapshot/stupicat-table-with-html-output" \
+    expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/table-with-html.md 2>/dev/null"
+)

--- a/tests/fixtures/snapshots/stupicat-table-with-html-output
+++ b/tests/fixtures/snapshots/stupicat-table-with-html-output
@@ -1,0 +1,7 @@
+# Heading
+
+|Head 1|Head 2|
+|------|------|
+|<span>Row 1</span>|Row 2|
+
+Paragraph

--- a/tests/fixtures/table-with-html.md
+++ b/tests/fixtures/table-with-html.md
@@ -1,0 +1,7 @@
+# Heading
+
+| Head 1 | Head 2 |
+|--------|--------|
+| <span>Row 1</span> | Row 2 |
+
+Paragraph

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -275,11 +275,11 @@ mod blockquote {
 
         assert_events_eq(s);
 
-        assert_eq!(fmts(s).0, "\n > \n > <table>\n > </table>\n > \n")
+        assert_eq!(fmts(s).0, "\n > \n > <table>\n > </table>\n > ")
     }
     #[test]
     fn with_inlinehtml() {
-        assert_eq!(fmts(" > <br>").0, "\n > \n > <br>\n")
+        assert_eq!(fmts(" > <br>").0, "\n > \n > <br>")
     }
     #[test]
     fn with_plaintext_in_html() {


### PR DESCRIPTION
This was reported initially here: https://github.com/badboy/mdbook-toc/issues/19