### PR TITLE
Handle spaces in link URIs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,11 +318,15 @@ where
             }
             End(ref tag) => match tag {
                 Image(_, ref uri, ref title) | Link(_, ref uri, ref title) => {
-                    if title.is_empty() {
-                        write!(formatter, "]({})", uri)
+                    if uri.contains(' ') {
+                        write!(formatter, "](<{uri}>", uri = uri)?;
                     } else {
-                        write!(formatter, "]({uri} \"{title}\")", uri = uri, title = title)
+                        write!(formatter, "]({uri}", uri = uri)?;
                     }
+                    if !title.is_empty() {
+                        write!(formatter, " \"{title}\"", title = title)?;
+                    }
+                    formatter.write_str(")")
                 }
                 Emphasis => formatter.write_char('*'),
                 Strong => formatter.write_str("**"),


### PR DESCRIPTION
Link destinations containing spaces need to be formatted like `[link](<containing spaces>)`.

This brings the number of passing CommonMark test cases from 387 to 388.