### PR TITLE
Don't output extra newlines after HTML before a SoftBreak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ where
                 Html(_) => { /* no newlines if HTML continues */ }
                 Text(_) => { /* no newlines for inline HTML */ }
                 End(_) => { /* no newlines if ending a previous opened tag */ }
+                SoftBreak => { /* SoftBreak will result in a newline later */ }
                 _ => {
                     // Ensure next Markdown block is rendered properly
                     // by adding a newline after an HTML element.

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -215,7 +215,7 @@ mod inline_elements {
         assert_eq!(
             fmts("*a* b **c**\n<br>\nd\n\ne `c`"),
             (
-                "*a* b **c**\n<br>\n\nd\n\ne `c`".into(),
+                "*a* b **c**\n<br>\nd\n\ne `c`".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()


### PR DESCRIPTION
Fixes #28.
