### PR TITLE
shortcut links implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "pulldown-cmark-to-cmark"
 version = "7.0.0"
-authors = ["Sebastian Thiel <byronimo@gmail.com>", "Dylan Owen <dyltotheo@gmail.com>"]
+authors = [
+    "Sebastian Thiel <byronimo@gmail.com>",
+    "Dylan Owen <dyltotheo@gmail.com>",
+    "Alessandro Ogier <alessandro.ogier@gmail.com>"]
 
 description = "Convert pulldown-cmark Events back to the string they were parsed from"
 license = "Apache-2.0"

--- a/tests/fixtures/common-mark.md
+++ b/tests/fixtures/common-mark.md
@@ -16,7 +16,7 @@ voluptua. `At vero eos et` accusam et
 
 ###### Level 6
 
-## Links
+## [Links]
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat
@@ -201,3 +201,5 @@ foo
 
 * | < > # 
 ````
+
+[Links]: http://www.example.com/shortcut

--- a/tests/fixtures/snapshots/stupicat-output
+++ b/tests/fixtures/snapshots/stupicat-output
@@ -16,7 +16,7 @@ voluptua. `At vero eos et` accusam et
 
 ###### Level 6
 
-## Links
+## [Links]
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat
@@ -200,3 +200,5 @@ foo
 
 * | < > # 
 ````
+
+[Links]: http://www.example.com/shortcut

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -215,6 +215,20 @@ mod inline_elements {
     }
 
     #[test]
+    fn shortcut_links() {
+        assert_eq!(
+            fmts("[a](b)\n[c]\n\n[c]: e"),
+            (
+                "[a](b)\n[c]\n\n[c]: e".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
     fn various() {
         assert_eq!(
             fmts("*a* b **c**\n<br>\nd\n\ne `c`"),


### PR DESCRIPTION
Hi! This PR implement an unopinionated management for `Linktype::Shortcut`s type links as identified by pulldown-cmark. Resulting output preserve the author's choice of putting a link in a file footer rather than inlining it.

I'm not totally convinced about `clone()`ing/reallocating stuff in required support data structures but being a rust newbie I'm currently unable to provide a better solution, given that there is any.

Hope this helps, thank you


see Byron/pulldown-cmark-to-cmark#32