### PR TITLE
retain autolink/email link format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "pulldown-cmark-to-cmark"
 version = "7.0.0"
-authors = ["Sebastian Thiel <byronimo@gmail.com>", "Dylan Owen <dyltotheo@gmail.com>"]
+authors = [
+    "Sebastian Thiel <byronimo@gmail.com>",
+    "Dylan Owen <dyltotheo@gmail.com>",
+    "Alessandro Ogier <alessandro.ogier@gmail.com>"]
 
 description = "Convert pulldown-cmark Events back to the string they were parsed from"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ where
     }
 
     for event in events {
-        use pulldown_cmark::{CodeBlockKind, Event::*, Tag::*};
+        use pulldown_cmark::{CodeBlockKind, Event::*, LinkType, Tag::*};
 
         let event = event.borrow();
 
@@ -288,6 +288,7 @@ where
                         state.store_next_text = true;
                         formatter.write_char('|')
                     }
+                    Link(LinkType::Autolink | LinkType::Email, ..) => formatter.write_char('<'),
                     Link(..) => formatter.write_char('['),
                     Image(..) => formatter.write_str("!["),
                     Emphasis => formatter.write_char(options.emphasis_token),
@@ -345,6 +346,7 @@ where
                 }
             }
             End(ref tag) => match tag {
+                Link(LinkType::Autolink | LinkType::Email, ..) => formatter.write_char('>'),
                 Image(_, ref uri, ref title) | Link(_, ref uri, ref title) => {
                     if uri.contains(' ') {
                         write!(formatter, "](<{uri}>", uri = uri)?;

--- a/tests/fixtures/common-mark.md
+++ b/tests/fixtures/common-mark.md
@@ -28,6 +28,8 @@ invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
 et accusam et [justo duo dolores][1] et ea rebum. Stet clita kasd gubergren, no
 sea [takimata sanctus](./showcase.md) est Lorem ipsum dolor sit amet.
 
+Ask to <user@example.com>.
+
 [1]: http://www.example.com/reference
 
 ## Images

--- a/tests/fixtures/snapshots/stupicat-output
+++ b/tests/fixtures/snapshots/stupicat-output
@@ -20,13 +20,15 @@ voluptua. `At vero eos et` accusam et
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat
-([http://www.example.com/autolink](http://www.example.com/autolink)), sed diam voluptua.
+(<http://www.example.com/autolink>), sed diam voluptua.
 
 Lorem ipsum dolor sit amet, [consetetur
 sadipscing](http://www.example.com/inline) elitr, sed diam nonumy eirmod tempor
 invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
 et accusam et [justo duo dolores](http://www.example.com/reference) et ea rebum. Stet clita kasd gubergren, no
 sea [takimata sanctus](./showcase.md) est Lorem ipsum dolor sit amet.
+
+Ask to <user@example.com>.
 
 ## Images
 

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -198,7 +198,7 @@ mod inline_elements {
     }
     #[test]
     fn autolinks_are_fully_resolved() {
-        assert_eq!(fmts("<http://a/b>").0, "[http://a/b](http://a/b)",)
+        assert_eq!(fmts("<http://a/b>").0, "<http://a/b>",)
     }
     #[test]
     fn links() {


### PR DESCRIPTION
This PR make library to retain autolink/email link format respecting author's choices.

Thank you, regards

see Byron/pulldown-cmark-to-cmark#23