### PR TITLE
Inserts a newline if there is no newline before code block termination fence

### DIFF
--- a/tests/cat.sh
+++ b/tests/cat.sh
@@ -75,3 +75,9 @@ title "stupicat"
     WITH_SNAPSHOT="$snapshot/stupicat-repeated-shortcut-links-output" \
     expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/repeated-shortcut-links.md 2>/dev/null"
 )
+
+(with "indented code block"
+  it "succeeds" && \
+    WITH_SNAPSHOT="$snapshot/stupicat-indented-code-block" \
+    expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/indented-code-block.md 2>/dev/null"
+)

--- a/tests/fixtures/indented-code-block.md
+++ b/tests/fixtures/indented-code-block.md
@@ -1,0 +1,5 @@
+codeblcok:
+
+    fn main() {
+      println!("Hello, world!");
+    }

--- a/tests/fixtures/snapshots/stupicat-indented-code-block
+++ b/tests/fixtures/snapshots/stupicat-indented-code-block
@@ -1,0 +1,7 @@
+codeblcok:
+
+````
+fn main() {
+  println!("Hello, world!");
+}
+````

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -105,6 +105,7 @@ fn it_applies_newlines_before_start_before_text() {
             &[Event::Text("t".into())],
             State {
                 newlines_before_start: 2,
+                last_was_text_without_trailing_newline: true,
                 ..Default::default()
             }
         ),
@@ -112,6 +113,7 @@ fn it_applies_newlines_before_start_before_text() {
             "\n\nt".into(),
             State {
                 newlines_before_start: 0,
+                last_was_text_without_trailing_newline: true,
                 ..Default::default()
             }
         )
@@ -125,6 +127,7 @@ fn it_applies_newlines_before_start_before_any_start_tag() {
             &[Event::Start(Tag::Paragraph), Event::Text("h".into())],
             State {
                 newlines_before_start: 2,
+                last_was_text_without_trailing_newline: true,
                 ..Default::default()
             }
         ),
@@ -132,6 +135,7 @@ fn it_applies_newlines_before_start_before_any_start_tag() {
             "\n\nh".into(),
             State {
                 newlines_before_start: 0,
+                last_was_text_without_trailing_newline: true,
                 ..Default::default()
             }
         )
@@ -149,6 +153,7 @@ mod padding {
                 State {
                     newlines_before_start: 2,
                     padding: vec!["  ".into()],
+                    last_was_text_without_trailing_newline: true,
                     ..Default::default()
                 }
             ),
@@ -157,6 +162,7 @@ mod padding {
                 State {
                     newlines_before_start: 0,
                     padding: vec!["  ".into()],
+                    last_was_text_without_trailing_newline: true,
                     ..Default::default()
                 }
             )


### PR DESCRIPTION
This PR also introduces a new public field `State::last_was_text_without_trailing_newline`.

fixes #48 