### PR TITLE
Add options for ordered list formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub struct Options<'a> {
     pub code_block_token_count: usize,
     pub code_block_token: char,
     pub list_token: char,
+    pub ordered_list_token: char,
     pub emphasis_token: char,
     pub strong_token: &'a str,
 }
@@ -96,6 +97,7 @@ const DEFAULT_OPTIONS: Options<'_> = Options {
     code_block_token_count: 4,
     code_block_token: '`',
     list_token: '*',
+    ordered_list_token: '.',
     emphasis_token: '*',
     strong_token: "**",
 };
@@ -294,7 +296,7 @@ where
                         Some(inner) => {
                             state.padding.push(padding_of(*inner));
                             match inner {
-                                Some(n) => write!(formatter, "{}. ", n),
+                                Some(n) => write!(formatter, "{}{} ", n, options.ordered_list_token),
                                 None => write!(formatter, "{} ", options.list_token),
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub struct Options<'a> {
     pub code_block_token: char,
     pub list_token: char,
     pub ordered_list_token: char,
+    pub increment_ordered_list_bullets: bool,
     pub emphasis_token: char,
     pub strong_token: &'a str,
 }
@@ -98,6 +99,7 @@ const DEFAULT_OPTIONS: Options<'_> = Options {
     code_block_token: '`',
     list_token: '*',
     ordered_list_token: '.',
+    increment_ordered_list_bullets: false,
     emphasis_token: '*',
     strong_token: "**",
 };
@@ -292,11 +294,17 @@ where
                 let consumed_newlines = state.newlines_before_start != 0;
                 consume_newlines(&mut formatter, &mut state)?;
                 match tag {
-                    Item => match state.list_stack.last() {
+                    Item => match state.list_stack.last_mut() {
                         Some(inner) => {
                             state.padding.push(padding_of(*inner));
                             match inner {
-                                Some(n) => write!(formatter, "{}{} ", n, options.ordered_list_token),
+                                Some(n) => {
+                                    let bullet_number = n.clone();
+                                    if options.increment_ordered_list_bullets {
+                                        *n += 1;
+                                    }
+                                    write!(formatter, "{}{} ", bullet_number, options.ordered_list_token)
+                                }
                                 None => write!(formatter, "{} ", options.list_token),
                             }
                         }

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -977,6 +977,24 @@ mod list {
     }
 
     #[test]
+    fn change_ordered_list_token() {
+        let custom_options = CmarkToCmarkOptions {
+            ordered_list_token: ')',
+            ..Default::default()
+        };
+        assert_eq!(
+            fmts_with_options("2. a\n2. b", custom_options),
+            (
+                "2) a\n2) b".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
     fn checkboxes() {
         assert_eq!(
             fmts(indoc!(

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -995,6 +995,111 @@ mod list {
     }
 
     #[test]
+    fn increment_ordered_list_bullets() {
+        let custom_options = CmarkToCmarkOptions {
+            increment_ordered_list_bullets: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            fmts_with_options("2. a\n2. b\n2. c", custom_options),
+            (
+                "2. a\n3. b\n4. c".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn nested_increment_ordered_list_bullets() {
+        let custom_options = CmarkToCmarkOptions {
+            increment_ordered_list_bullets: true,
+            ..Default::default()
+        };
+        let input = indoc!(
+            "
+        1. level 1
+           1. level 2
+              1. level 3
+              1. level 3
+           1. level 2
+        1. level 1"
+        );
+
+        let expected = indoc!(
+            "
+        1. level 1
+           1. level 2
+              1. level 3
+              2. level 3
+           2. level 2
+        2. level 1"
+        );
+        assert_eq!(
+            fmts_with_options(input, custom_options),
+            (
+                expected.into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn nested_increment_ordered_list_bullets_change_ordered_list_token() {
+        let custom_options = CmarkToCmarkOptions {
+            increment_ordered_list_bullets: true,
+            ordered_list_token: ')',
+            ..Default::default()
+        };
+        let input = indoc!(
+            "
+        1. level 1
+           1. level 2
+              1. level 3
+              1. level 3
+           1. level 2
+        1. level 1
+        1. level 1
+           1. level 2
+              1. level 3
+              1. level 3
+           1. level 2
+        1. level 1"
+        );
+
+        let expected = indoc!(
+            "
+        1) level 1
+           1) level 2
+              1) level 3
+              2) level 3
+           2) level 2
+        2) level 1
+        3) level 1
+           1) level 2
+              1) level 3
+              2) level 3
+           2) level 2
+        4) level 1"
+        );
+        assert_eq!(
+            fmts_with_options(input, custom_options),
+            (
+                expected.into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
     fn checkboxes() {
         assert_eq!(
             fmts(indoc!(


### PR DESCRIPTION
This PR adds `ordered_list_token` and `increment_ordered_list_bullets` fields to the `Options` struct to allow users to control the ordered list marker they want to use (`.` or `)`) and allows users to specify if they want to increment the ordered list number.

For example, setting `ordered_list_token=')'` and `increment_ordered_list_bullets=true` will format the following:

```markdown
1. one
1. two
1. three
```
as:

```markdown
1) one
2) two
3) three
```