### PR TITLE
Handle inline code spans with multiple backticks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
     borrow::{Borrow, Cow},
     collections::HashSet,
     fmt,
-    iter::FromIterator,
 };
 
 use pulldown_cmark::{Alignment as TableAlignment, Event, HeadingLevel, LinkType};
@@ -265,20 +264,10 @@ where
                     shortcut_text.push_str(&format!("`{}`", text));
                 }
                 if let Some(text_for_header) = state.text_for_header.as_mut() {
-                    let code = format!("{}{}{}", options.code_block_token, text, options.code_block_token);
+                    let code = format!("`{}`", text);
                     text_for_header.push_str(&code);
                 }
-                let (start, end) = if text.contains(options.code_block_token) {
-                    (
-                        String::from_iter([options.code_block_token, options.code_block_token, ' ']),
-                        String::from_iter([' ', options.code_block_token, options.code_block_token]),
-                    )
-                } else {
-                    (
-                        String::from(options.code_block_token),
-                        String::from(options.code_block_token),
-                    )
-                };
+                let (start, end) = if text.contains('`') { ("`` ", " ``") } else { ("`", "`") };
                 formatter
                     .write_str(&start)
                     .and_then(|_| formatter.write_str(text))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ where
     F: fmt::Write,
 {
     let mut state = state.unwrap_or_default();
-    fn padding<'a, F>(f: &mut F, p: &[Cow<'a, str>]) -> fmt::Result
+    fn padding<F>(f: &mut F, p: &[Cow<'_, str>]) -> fmt::Result
     where
         F: fmt::Write,
     {
@@ -199,7 +199,7 @@ where
         }
     }
 
-    fn print_text_without_trailing_newline<'a, F>(t: &str, f: &mut F, p: &[Cow<'a, str>]) -> fmt::Result
+    fn print_text_without_trailing_newline<F>(t: &str, f: &mut F, p: &[Cow<'_, str>]) -> fmt::Result
     where
         F: fmt::Write,
     {

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -286,7 +286,7 @@ mod inline_elements {
 
         let (s, state) = fmts_with_options("_a_ b **c**\n<br>\nd\n\ne `c`", custom_options);
 
-        assert_eq!(s, "_a_ b **c**\n<br>\nd\n\ne ~c~".to_string());
+        assert_eq!(s, "_a_ b **c**\n<br>\nd\n\ne `c`".to_string());
         assert_eq!(
             state,
             State {

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -306,7 +306,67 @@ mod inline_elements {
         assert_eq!(
             fmts("lorem ``ipsum `dolor` sit`` amet"),
             (
-                "lorem `` ipsum `dolor` sit `` amet".into(),
+                "lorem ``ipsum `dolor` sit`` amet".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn code_triple_backtick() {
+        assert_eq!(
+            fmts("lorem ```ipsum ``dolor`` sit``` amet"),
+            (
+                "lorem ```ipsum ``dolor`` sit``` amet".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn code_backtick_normalization() {
+        // The minimum amount of backticks are inserted.
+        assert_eq!(
+            fmts("lorem ```ipsum ` dolor``` amet"),
+            (
+                "lorem ``ipsum ` dolor`` amet".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn code_leading_trailing_backtick() {
+        // Spaces are inserted if the inline code starts or ends with
+        // a backtick.
+        assert_eq!(
+            fmts("`` `lorem ``   `` ipsum` ``"),
+            (
+                "`` `lorem ``   `` ipsum` ``".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn code_spaces_before_backtick() {
+        //  No space is inserted if it is not needed.
+        assert_eq!(
+            fmts("` lorem `   ` `"),
+            (
+                "`lorem`   ` `".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()


### PR DESCRIPTION
Before, `options.code_block_token` was used for inline code spans. Now we always use a backtick.

As far as I can tell from the [reference][1] and from [experimentation][2], code spans should always use one or more backticks and never use something else such as tildes.

The PR also ensures that we insert the necessary number of backticks to quote any backticks found in the code span itself. Before, only the case with a single backtick was handled, now the code can contain arbitrarily many backticks.

This was found using a fuzz test like the one in #55. The difference is that I restricted the input to a single paragraph of Markdown text, meaning that it only fuzzes inputs which match

    [Event::Start(Tag::Paragraph), .., Event::End(Tag::Paragraph)]

There seems to be some more corner cases that are not handled already, so I'll try to send more PRs to fix those.

[1]: https://spec.commonmark.org/0.30/#code-spans
[2]: https://spec.commonmark.org/dingus/?text=%60foo%60%0A