### PR TITLE
Fix multiline footnotes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,10 @@ where
                     Image(..) => formatter.write_str("!["),
                     Emphasis => formatter.write_char(options.emphasis_token),
                     Strong => formatter.write_str(options.strong_token),
-                    FootnoteDefinition(ref name) => write!(formatter, "[^{}]: ", name),
+                    FootnoteDefinition(ref name) => {
+                        state.padding.push("    ".into());
+                        write!(formatter, "[^{}]: ", name)
+                    }
                     Paragraph => Ok(()),
                     Heading(level, _, _) => {
                         match level {
@@ -518,7 +521,10 @@ where
 
                     Ok(())
                 }
-                FootnoteDefinition(_) => Ok(()),
+                FootnoteDefinition(_) => {
+                    state.padding.pop();
+                    Ok(())
+                }
                 Strikethrough => formatter.write_str("~~"),
             },
             HardBreak => formatter.write_str("  \n").and(padding(&mut formatter, &state.padding)),

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -192,9 +192,9 @@ mod inline_elements {
     #[test]
     fn footnote() {
         assert_eq!(
-            fmts("a [^b]\n[^b]: c"),
+            fmts("a [^b]\n\n[^b]: c"),
             (
-                "a [^b]\n[^b]: c".into(),
+                "a [^b]\n\n[^b]: c".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()
@@ -202,6 +202,15 @@ mod inline_elements {
             )
         )
     }
+
+    #[test]
+    fn multiline_footnote() {
+        assert_eq!(
+            fmts("a [^b]\n\n[^b]: this is\n    one footnote").0,
+            "a [^b]\n\n[^b]: this is\n    one footnote",
+        )
+    }
+
     #[test]
     fn autolinks_are_fully_resolved() {
         assert_eq!(fmts("<http://a/b>").0, "<http://a/b>",)


### PR DESCRIPTION
Currently, multiline footnotes are written out without indentation, which results in only the first line being interpreted as part of the footnote. This fixes that by writing four spaces before each subsequent line of a multiline footnote.

Also, according to [pandoc](https://pandoc.org/MANUAL.html#footnotes) and it seems `pulldown_cmark`, footnotes need to be separated by blank lines from other content, so I updated the existing test accordingly.