### PR TITLE
Escape double quotes in link titles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::{Borrow, Cow},
     collections::HashSet,
-    fmt,
+    fmt::{self, Write},
 };
 
 use pulldown_cmark::{Alignment as TableAlignment, Event, HeadingLevel, LinkType};
@@ -599,13 +599,16 @@ where
 
 struct EscapeLinkTitle<'a>(&'a str);
 
+/// Writes a link title with double quotes escaped.
+/// See https://spec.commonmark.org/0.30/#link-title for the rules around
+/// link titles and the characters they may contain.
 impl fmt::Display for EscapeLinkTitle<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for c in self.0.bytes() {
+        for c in self.0.chars() {
             match c {
-                b'"' => write!(f, r#"\""#)?,
-                b'\\' => write!(f, r"\\")?,
-                c => write!(f, "{}", c as char)?,
+                '"' => f.write_str(r#"\""#)?,
+                '\\' => f.write_str(r"\\")?,
+                c => f.write_char(c)?,
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,13 +588,28 @@ where
         write!(f, "]{}{uri}", separator, uri = uri)?;
     }
     if !title.is_empty() {
-        write!(f, " \"{title}\"", title = title)?;
+        write!(f, " \"{title}\"", title = EscapeLinkTitle(title))?;
     }
     if link_type != LinkType::Shortcut {
         f.write_char(')')?;
     }
 
     Ok(())
+}
+
+struct EscapeLinkTitle<'a>(&'a str);
+
+impl fmt::Display for EscapeLinkTitle<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for c in self.0.bytes() {
+            match c {
+                b'"' => write!(f, r#"\""#)?,
+                b'\\' => write!(f, r"\\")?,
+                c => write!(f, "{}", c as char)?,
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<'a> State<'a> {

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -873,6 +873,32 @@ mod escapes {
     }
 
     #[test]
+    fn link_titles() {
+        // See https://spec.commonmark.org/0.30/#link-title for the rules around
+        // link titles and the characters they may contain
+        assert_eq!(
+            fmts(r#"[link](http://example.com "'link title'")"#).0,
+            r#"[link](http://example.com "'link title'")"#
+        );
+        assert_eq!(
+            fmts(r#"[link](http://example.com "\"link title\"")"#).0,
+            r#"[link](http://example.com "\"link title\"")"#
+        );
+        assert_eq!(
+            fmts(r#"[link](http://example.com '"link title"')"#).0,
+            r#"[link](http://example.com "\"link title\"")"#
+        );
+        assert_eq!(
+            fmts(r#"[link](http://example.com '\'link title\'')"#).0,
+            r#"[link](http://example.com "'link title'")"#
+        );
+        assert_eq!(
+            fmts(r#"[link](http://example.com (\(link title\)))"#).0,
+            r#"[link](http://example.com "(link title)")"#
+        );
+    }
+
+    #[test]
     fn it_does_esscape_lone_square_brackets_in_text() {
         assert_eq!(
             fmts("] a closing bracket does nothing").0,

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -881,6 +881,10 @@ mod escapes {
             r#"[link](http://example.com "'link title'")"#
         );
         assert_eq!(
+            fmts(r#"[link](http://example.com "\\\"link \\ title\"")"#).0,
+            r#"[link](http://example.com "\\\"link \\ title\"")"#
+        );
+        assert_eq!(
             fmts(r#"[link](http://example.com "\"link title\"")"#).0,
             r#"[link](http://example.com "\"link title\"")"#
         );

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -900,6 +900,10 @@ mod escapes {
             fmts(r#"[link](http://example.com (\(link title\)))"#).0,
             r#"[link](http://example.com "(link title)")"#
         );
+        assert_eq!(
+            fmts(r#"[link](http://example.com (你好👋))"#).0,
+            r#"[link](http://example.com "你好👋")"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
Currently, link titles are written without any escaping:
https://github.com/Byron/pulldown-cmark-to-cmark/blob/b1f77e0526b59a04234c0874cf00493720da550a/src/lib.rs#L591

This breaks links if the title contains interior quotes (see included test).

Since we always write link titles surrounded by double quotes, we should escape any interior double quotes that aren't already escaped.

See also https://spec.commonmark.org/0.30/#link-title