### PR TITLE
Update `pulldown-cmark` and mdBook links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This library takes great pride in supporting **everything that `pulldown-cmark`*
 including *tables* and *footnotes* and *codeblocks in codeblocks*,
 while assuring *quality* with a powerful test suite.
 
-[pdcm-event]: https://docs.rs/pulldown-cmark/0.1.0/pulldown_cmark/enum.Event.html
-[mdbook-prep]: https://rust-lang-nursery.github.io/mdBook/for_developers/preprocessors.html
+[pdcm-event]: https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.Event.html
+[mdbook-prep]: https://rust-lang.github.io/mdBook/for_developers/preprocessors.html
 
 ### How to use
 


### PR DESCRIPTION
The current links are old, pointing to `pulldown-cmark` 0.1.0 instead of 0.9.3 and to an old deployment of the mdbook guide