### PR TITLE
Update `pulldown-cmark` dependency to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 include = ["src/lib.rs", "LICENSE-APACHE", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-pulldown-cmark = { version = "0.9.0", default-features = false }
+pulldown-cmark = { version = "0.10.0", default-features = false }
 
 [dev-dependencies]
 indoc = "1.0.0"

--- a/examples/stupicat.rs
+++ b/examples/stupicat.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn read_to_string(path: OsString) -> String {
-    let mut file = File::open(&path).expect("file to exist for reading");
+    let mut file = File::open(path).expect("file to exist for reading");
     let mut buf = String::new();
     file.read_to_string(&mut buf).expect("file to be readable");
     buf

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,9 +181,9 @@ impl<'a> Options<'a> {
 pub fn cmark_resume_with_options<'a, I, E, F>(
     events: I,
     mut formatter: F,
-    state: Option<State<'static>>,
+    state: Option<State<'a>>,
     options: Options<'_>,
-) -> Result<State<'static>, fmt::Error>
+) -> Result<State<'a>, fmt::Error>
 where
     I: Iterator<Item = E>,
     E: Borrow<Event<'a>>,
@@ -658,11 +658,7 @@ where
 }
 
 /// As [`cmark_resume_with_options()`], but with default [`Options`].
-pub fn cmark_resume<'a, I, E, F>(
-    events: I,
-    formatter: F,
-    state: Option<State<'static>>,
-) -> Result<State<'static>, fmt::Error>
+pub fn cmark_resume<'a, I, E, F>(events: I, formatter: F, state: Option<State<'a>>) -> Result<State<'a>, fmt::Error>
 where
     I: Iterator<Item = E>,
     E: Borrow<Event<'a>>,
@@ -741,7 +737,7 @@ pub fn cmark_with_options<'a, I, E, F>(
     events: I,
     mut formatter: F,
     options: Options<'_>,
-) -> Result<State<'static>, fmt::Error>
+) -> Result<State<'a>, fmt::Error>
 where
     I: Iterator<Item = E>,
     E: Borrow<Event<'a>>,
@@ -752,7 +748,7 @@ where
 }
 
 /// As [`cmark_with_options()`], but with default [`Options`].
-pub fn cmark<'a, I, E, F>(events: I, mut formatter: F) -> Result<State<'static>, fmt::Error>
+pub fn cmark<'a, I, E, F>(events: I, mut formatter: F) -> Result<State<'a>, fmt::Error>
 where
     I: Iterator<Item = E>,
     E: Borrow<Event<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     fmt::{self, Write},
 };
 
-use pulldown_cmark::{Alignment as TableAlignment, Event, HeadingLevel, LinkType, Tag, TagEnd};
+use pulldown_cmark::{Alignment as TableAlignment, Event, HeadingLevel, LinkType, MetadataBlockKind, Tag, TagEnd};
 
 /// Similar to [Pulldown-Cmark-Alignment][Alignment], but with required
 /// traits for comparison to allow testing.
@@ -397,6 +397,8 @@ where
                         .and_then(|_| padding(&mut formatter, &state.padding))
                     }
                     HtmlBlock => Ok(()),
+                    MetadataBlock(MetadataBlockKind::YamlStyle) => formatter.write_str("---\n"),
+                    MetadataBlock(MetadataBlockKind::PlusesStyle) => formatter.write_str("+++\n"),
                     List(_) => Ok(()),
                     Strikethrough => formatter.write_str("~~"),
                 }
@@ -462,6 +464,8 @@ where
                     }
                     Ok(())
                 }
+                TagEnd::MetadataBlock(MetadataBlockKind::PlusesStyle) => formatter.write_str("+++"),
+                TagEnd::MetadataBlock(MetadataBlockKind::YamlStyle) => formatter.write_str("..."),
                 TagEnd::Table => {
                     if state.newlines_before_start < options.newlines_after_table {
                         state.newlines_before_start = options.newlines_after_table;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,6 @@ pub struct State<'a> {
     pub text_for_header: Option<String>,
     /// Is set while we are handling text in a code block
     pub is_in_code_block: bool,
-    /// True if the last event was html. Used to inject additional newlines to support markdown inside of HTML tags.
-    pub last_was_html: bool,
     /// True if the last event was text and the text does not have trailing newline. Used to inject additional newlines before code block end fence.
     pub last_was_text_without_trailing_newline: bool,
     /// Currently open links

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ where
                         link_type,
                         dest_url,
                         title,
-                        id,
+                        id: _,
                     } => {
                         state.link_stack.push(match link_type {
                             LinkType::Autolink | LinkType::Email => {
@@ -374,10 +374,10 @@ where
                         Ok(())
                     }
                     Image {
-                        link_type,
+                        link_type: _,
                         dest_url,
                         title,
-                        id,
+                        id: _,
                     } => {
                         state.image_stack.push(ImageLink {
                             uri: dest_url.to_string(),
@@ -396,7 +396,7 @@ where
                         level,
                         id,
                         classes,
-                        attrs,
+                        attrs: _,
                     } => {
                         assert_eq!(state.current_heading, None);
                         state.current_heading = Some((

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -170,15 +170,7 @@ mod start {
 }
 
 mod end {
-    use pulldown_cmark::{
-        Alignment::{self, Center, Left, Right},
-        CodeBlockKind,
-        Event::*,
-        HeadingLevel,
-        LinkType::*,
-        Tag::*,
-        TagEnd,
-    };
+    use pulldown_cmark::{Event::*, HeadingLevel, TagEnd};
 
     use super::s;
 
@@ -222,41 +214,41 @@ mod end {
     fn item() {
         assert_eq!(s(End(TagEnd::Item)), "")
     }
-    #[test]
-    fn link() {
-        assert_eq!(
-            s(End(TagEnd::Link {
-                link_type: Inline,
-                dest_url: "/uri".into(),
-                title: "title".into(),
-                id: "".into()
-            })),
-            "](/uri \"title\")"
-        )
-    }
-    #[test]
-    fn link_without_title() {
-        assert_eq!(
-            s(End(TagEnd::Link {
-                link_type: Inline,
-                dest_url: "/uri".into(),
-                title: "".into(),
-                id: "".into()
-            })),
-            "](/uri)"
-        )
-    }
-    #[test]
-    fn image() {
-        assert_eq!(
-            s(End(TagEnd::Image(Inline, "/uri".into(), "title".into()))),
-            "](/uri \"title\")"
-        )
-    }
-    #[test]
-    fn image_without_title() {
-        assert_eq!(s(End(TagEnd::Image(Inline, "/uri".into(), "".into()))), "](/uri)")
-    }
+    // #[test]
+    // fn link() {
+    //     assert_eq!(
+    //         s(End(TagEnd::Link {
+    //             link_type: Inline,
+    //             dest_url: "/uri".into(),
+    //             title: "title".into(),
+    //             id: "".into()
+    //         })),
+    //         "](/uri \"title\")"
+    //     )
+    // }
+    // #[test]
+    // fn link_without_title() {
+    //     assert_eq!(
+    //         s(End(TagEnd::Link {
+    //             link_type: Inline,
+    //             dest_url: "/uri".into(),
+    //             title: "".into(),
+    //             id: "".into()
+    //         })),
+    //         "](/uri)"
+    //     )
+    // }
+    // #[test]
+    // fn image() {
+    //     assert_eq!(
+    //         s(End(TagEnd::Image(Inline, "/uri".into(), "title".into()))),
+    //         "](/uri \"title\")"
+    //     )
+    // }
+    // #[test]
+    // fn image_without_title() {
+    //     assert_eq!(s(End(TagEnd::Image(Inline, "/uri".into(), "".into()))), "](/uri)")
+    // }
     #[test]
     fn table() {
         assert_eq!(s(End(TagEnd::Table)), "")

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -46,11 +46,27 @@ mod start {
     }
     #[test]
     fn header1() {
-        assert_eq!(s(Start(Heading(HeadingLevel::H1, None, vec![]))), "# ")
+        assert_eq!(
+            s(Start(Heading {
+                level: HeadingLevel::H1,
+                id: None,
+                classes: vec![],
+                attrs: vec![]
+            })),
+            "# "
+        )
     }
     #[test]
     fn header2() {
-        assert_eq!(s(Start(Heading(HeadingLevel::H2, None, vec![]))), "## ")
+        assert_eq!(
+            s(Start(Heading {
+                level: HeadingLevel::H2,
+                id: None,
+                classes: vec![],
+                attrs: vec![]
+            })),
+            "## "
+        )
     }
     #[test]
     fn blockquote() {
@@ -89,19 +105,51 @@ mod start {
     }
     #[test]
     fn link() {
-        assert_eq!(s(Start(Link(Inline, "uri".into(), "title".into()))), "[")
+        assert_eq!(
+            s(Start(Link {
+                link_type: Inline,
+                dest_url: "uri".into(),
+                title: "title".into(),
+                id: "".into(),
+            })),
+            "["
+        )
     }
     #[test]
     fn link_without_title() {
-        assert_eq!(s(Start(Link(Inline, "uri".into(), "".into()))), "[")
+        assert_eq!(
+            s(Start(Link {
+                link_type: Inline,
+                dest_url: "uri".into(),
+                title: "".into(),
+                id: "".into()
+            })),
+            "["
+        )
     }
     #[test]
     fn image() {
-        assert_eq!(s(Start(Image(Inline, "uri".into(), "title".into()))), "![")
+        assert_eq!(
+            s(Start(Image {
+                link_type: Inline,
+                dest_url: "uri".into(),
+                title: "title".into(),
+                id: "".into()
+            })),
+            "!["
+        )
     }
     #[test]
     fn image_without_title() {
-        assert_eq!(s(Start(Image(Inline, "uri".into(), "".into()))), "![")
+        assert_eq!(
+            s(Start(Image {
+                link_type: Inline,
+                dest_url: "uri".into(),
+                title: "".into(),
+                id: "".into()
+            })),
+            "!["
+        )
     }
     #[test]
     fn table() {
@@ -129,80 +177,97 @@ mod end {
         HeadingLevel,
         LinkType::*,
         Tag::*,
+        TagEnd,
     };
 
     use super::s;
 
     #[test]
     fn header() {
-        assert_eq!(s(End(Heading(HeadingLevel::H2, None, vec![]))), "")
+        assert_eq!(s(End(TagEnd::Heading(HeadingLevel::H2))), "")
     }
     #[test]
     fn paragraph() {
-        assert_eq!(s(End(Paragraph)), "")
+        assert_eq!(s(End(TagEnd::Paragraph)), "")
     }
     #[test]
     fn blockquote() {
-        assert_eq!(s(End(BlockQuote)), "")
+        assert_eq!(s(End(TagEnd::BlockQuote)), "")
     }
     #[test]
     fn codeblock() {
-        assert_eq!(s(End(CodeBlock(CodeBlockKind::Fenced("asdf".into())))), "````")
+        assert_eq!(s(End(TagEnd::CodeBlock)), "````")
     }
     #[test]
     fn footnote_definition() {
-        assert_eq!(s(End(FootnoteDefinition("asdf".into()))), "")
+        assert_eq!(s(End(TagEnd::FootnoteDefinition)), "")
     }
     #[test]
     fn emphasis() {
-        assert_eq!(s(End(Emphasis)), "*")
+        assert_eq!(s(End(TagEnd::Emphasis)), "*")
     }
     #[test]
     fn strong() {
-        assert_eq!(s(End(Strong)), "**")
+        assert_eq!(s(End(TagEnd::Strong)), "**")
     }
     #[test]
     fn list_unordered() {
-        assert_eq!(s(End(List(None))), "")
+        assert_eq!(s(End(TagEnd::List(false))), "")
     }
     #[test]
     fn list_ordered() {
-        assert_eq!(s(End(List(Some(1)))), "")
+        assert_eq!(s(End(TagEnd::List(true))), "")
     }
     #[test]
     fn item() {
-        assert_eq!(s(End(Item)), "")
+        assert_eq!(s(End(TagEnd::Item)), "")
     }
     #[test]
     fn link() {
-        assert_eq!(s(End(Link(Inline, "/uri".into(), "title".into()))), "](/uri \"title\")")
+        assert_eq!(
+            s(End(TagEnd::Link {
+                link_type: Inline,
+                dest_url: "/uri".into(),
+                title: "title".into(),
+                id: "".into()
+            })),
+            "](/uri \"title\")"
+        )
     }
     #[test]
     fn link_without_title() {
-        assert_eq!(s(End(Link(Inline, "/uri".into(), "".into()))), "](/uri)")
+        assert_eq!(
+            s(End(TagEnd::Link {
+                link_type: Inline,
+                dest_url: "/uri".into(),
+                title: "".into(),
+                id: "".into()
+            })),
+            "](/uri)"
+        )
     }
     #[test]
     fn image() {
         assert_eq!(
-            s(End(Image(Inline, "/uri".into(), "title".into()))),
+            s(End(TagEnd::Image(Inline, "/uri".into(), "title".into()))),
             "](/uri \"title\")"
         )
     }
     #[test]
     fn image_without_title() {
-        assert_eq!(s(End(Image(Inline, "/uri".into(), "".into()))), "](/uri)")
+        assert_eq!(s(End(TagEnd::Image(Inline, "/uri".into(), "".into()))), "](/uri)")
     }
     #[test]
     fn table() {
-        assert_eq!(s(End(Table(vec![Left, Center, Right, Alignment::None]))), "")
+        assert_eq!(s(End(TagEnd::Table)), "")
     }
     #[test]
     fn table_row() {
-        assert_eq!(s(End(TableRow)), "|")
+        assert_eq!(s(End(TagEnd::TableRow)), "|")
     }
     #[test]
     fn table_cell() {
-        assert_eq!(s(End(TableCell)), "")
+        assert_eq!(s(End(TagEnd::TableCell)), "")
     }
 }
 

--- a/tests/fixtures/heading-id-classes.md
+++ b/tests/fixtures/heading-id-classes.md
@@ -5,3 +5,5 @@
 ## with class {.classh2}
 
 ### multiple {#myh3 .classh3}
+
+# text { #id .class1 .class2 myattr, other_attr=myvalue }

--- a/tests/fixtures/snapshots/stupicat-event-by-event-output
+++ b/tests/fixtures/snapshots/stupicat-event-by-event-output
@@ -65,7 +65,7 @@ Ordered lists:
 1. dolor sit amet
    1. Nested
    
-   1. With 
+   1. With
       Paragraphs and nested blocks:
       
        > 

--- a/tests/fixtures/snapshots/stupicat-heading-id-classes-output
+++ b/tests/fixtures/snapshots/stupicat-heading-id-classes-output
@@ -1,7 +1,7 @@
 # nothing
 
-# with ID {#myh1}
+# with ID { #myh1 }
 
-## with class {.classh2}
+## with class { .classh2 }
 
-### multiple {#myh3 .classh3}
+### multiple { #myh3 .classh3 }

--- a/tests/fixtures/snapshots/stupicat-heading-id-classes-output
+++ b/tests/fixtures/snapshots/stupicat-heading-id-classes-output
@@ -5,3 +5,5 @@
 ## with class { .classh2 }
 
 ### multiple { #myh3 .classh3 }
+
+# text { #id .class1 .class2 myattr, other_attr=myvalue }

--- a/tests/fixtures/snapshots/stupicat-nested-output
+++ b/tests/fixtures/snapshots/stupicat-nested-output
@@ -3,6 +3,7 @@
 *emphasized*
 
 </div>
+
 <div>
 second line
 </div>

--- a/tests/fixtures/snapshots/stupicat-output
+++ b/tests/fixtures/snapshots/stupicat-output
@@ -65,7 +65,7 @@ Ordered lists:
 1. dolor sit amet
    1. Nested
    
-   1. With 
+   1. With
       Paragraphs and nested blocks:
       
        > 

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -1227,3 +1227,13 @@ mod list {
         );
     }
 }
+
+mod heading {
+    use super::assert_events_eq;
+
+    #[test]
+    fn heading_with_classes_and_attrs() {
+        assert_events_eq("# Heading { #id .class1 key1=val1 .class2 }");
+        assert_events_eq("# Heading { #id .class1 .class2 key1=val1 key2 }");
+    }
+}

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -4,25 +4,25 @@ extern crate indoc;
 use pulldown_cmark::{Alignment, CodeBlockKind, Event, LinkType, Options, Parser, Tag, TagEnd};
 use pulldown_cmark_to_cmark::{cmark, cmark_resume, cmark_resume_with_options, Options as CmarkToCmarkOptions, State};
 
-fn fmts(s: &str) -> (String, State<'static>) {
+fn fmts(s: &str) -> (String, State<'_>) {
     let mut buf = String::new();
     let s = cmark(Parser::new_ext(s, Options::all()), &mut buf).unwrap();
     (buf, s)
 }
 
-fn fmts_with_options(s: &str, options: CmarkToCmarkOptions) -> (String, State<'static>) {
+fn fmts_with_options<'a>(s: &'a str, options: CmarkToCmarkOptions<'a>) -> (String, State<'a>) {
     let mut buf = String::new();
     let s = cmark_resume_with_options(Parser::new_ext(s, Options::all()), &mut buf, None, options).unwrap();
     (buf, s)
 }
 
-fn fmtes(e: &[Event], s: State<'static>) -> (String, State<'static>) {
+fn fmtes<'a>(e: &'a [Event], s: State<'a>) -> (String, State<'a>) {
     let mut buf = String::new();
     let s = cmark_resume(e.iter(), &mut buf, Some(s)).unwrap();
     (buf, s)
 }
 
-fn fmte<'a>(e: impl AsRef<[Event<'a>]>) -> (String, State<'static>) {
+fn fmte<'a>(e: impl AsRef<[Event<'a>]>) -> (String, State<'a>) {
     let mut buf = String::new();
     let s = cmark(e.as_ref().iter(), &mut buf).unwrap();
     (buf, s)

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -47,7 +47,7 @@ mod lazy_newlines {
 
     #[test]
     fn after_emphasis_there_is_no_newline() {
-        for t in &[
+        for t in [
             Tag::Emphasis,
             Tag::Strong,
             Tag::Link {
@@ -64,8 +64,9 @@ mod lazy_newlines {
             },
             Tag::FootnoteDefinition("".into()),
         ] {
+            let end = t.to_end();
             assert_eq!(
-                fmte(&[Event::End(t.to_end())]).1,
+                fmte(&[Event::Start(t), Event::End(end)]).1,
                 State {
                     newlines_before_start: 0,
                     ..Default::default()

--- a/tests/integrate.rs
+++ b/tests/integrate.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod calculate_code_block_token_count {
-    use pulldown_cmark::{CodeBlockKind, CowStr, Event, Tag};
+    use pulldown_cmark::{CodeBlockKind, CowStr, Event, Tag, TagEnd};
     use pulldown_cmark_to_cmark::calculate_code_block_token_count;
 
     const CODE_BLOCK_START: Event<'_> = Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(CowStr::Borrowed(""))));
-    const CODE_BLOCK_END: Event<'_> = Event::End(Tag::CodeBlock(CodeBlockKind::Fenced(CowStr::Borrowed(""))));
+    const CODE_BLOCK_END: Event<'_> = Event::End(TagEnd::CodeBlock);
 
     #[test]
     fn no_token() {

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 use pulldown_cmark_to_cmark::cmark;
 
 const COMMONMARK_SPEC_TEXT: &str = include_str!("./spec/CommonMark/spec.txt");
@@ -23,7 +23,7 @@ fn collect_test_case<'a>(events: &mut impl Iterator<Item = Event<'a>>) -> Option
     let end_tag = events
         .next()
         .and_then(|e| if let Event::End(tag) = e { Some(tag) } else { None })?;
-    if !(is_example_fence(&begin_tag) && is_example_fence(&end_tag)) {
+    if !(is_example_fence(&begin_tag) && end_tag == TagEnd::CodeBlock) {
         return None;
     }
     let splitted_text = text.split("\n.\n").collect::<Vec<_>>();


### PR DESCRIPTION
[Version 0.10 of `pulldown-cmark` was just released with a number of breaking changes](https://github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.10.0). Unfortunately, it doesn't seem straightforward to update `pulldown-cmark-to-cmark`'s dependency on it. This is a start, but there are some breaking changes that will have to be worked around (compilation currently errors)