### PR TITLE
Fix emitting `::` for centered column in table.

### DIFF
--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -909,7 +909,42 @@ mod table {
             indoc!(
                 "
             |Tables|Are|Cool|yo||
-            |------|:-:|---:|:-|--|
+            |------|:-:|---:|:-|-|
+            |col 3 is|right-aligned|$1600|x|01|
+            |col 2 is|centered|$12|y|02|
+            |zebra stripes|are neat|$1|z|03|"
+            )
+        );
+
+        let p = Parser::new_ext(&generated_markdown, Options::all());
+        let generated_events: Vec<_> = p.into_iter().collect();
+
+        assert_eq!(original_events, generated_events);
+    }
+
+    #[test]
+    fn it_generates_equivalent_table_markdown_with_empty_headers() {
+        use pulldown_cmark::{Options, Parser};
+
+        let original_table_markdown = indoc!(
+            "
+            ||||||
+            |:-------------:|:--------------|------:|:--:|:-:|
+            | col 3 is      | right-aligned | $1600 | x  |01|
+            | col 2 is      | centered      |   $12 | y  |02|
+            | zebra stripes | are neat      |    $1 | z  |03|"
+        );
+        let p = Parser::new_ext(original_table_markdown, Options::all());
+        let original_events: Vec<_> = p.into_iter().collect();
+
+        let (generated_markdown, _) = fmte(&original_events);
+
+        assert_eq!(
+            generated_markdown,
+            indoc!(
+                "
+            ||||||
+            |:-:|:-|-:|:-:|:-:|
             |col 3 is|right-aligned|$1600|x|01|
             |col 2 is|centered|$12|y|02|
             |zebra stripes|are neat|$1|z|03|"


### PR DESCRIPTION
Emitting `::` in a table to indicate alignment is `Center` seems to break some parsers (at least `mdbook`'s). Emitting `:-:` appears to work fine.

This commit also removes an allocation when encountering an empty header cell. Rather than allocating a non-empty string, let the string be empty and add a minimum width for emitting alignments.

Also, I replaced what I think is a mismatch between characters and bytes in:
```rs
let last_minus_one = name.chars().count().saturating_sub(1);
for c in 0..name.len() {
```
`last_minus_one` counts in `char`s, while `c` counts in bytes.

This might fix #70.