### PR TITLE
Clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,10 @@ pub enum Alignment {
 impl<'a> From<&'a TableAlignment> for Alignment {
     fn from(s: &'a TableAlignment) -> Self {
         match *s {
-            TableAlignment::None => Alignment::None,
-            TableAlignment::Left => Alignment::Left,
-            TableAlignment::Center => Alignment::Center,
-            TableAlignment::Right => Alignment::Right,
+            TableAlignment::None => Self::None,
+            TableAlignment::Left => Self::Left,
+            TableAlignment::Center => Self::Center,
+            TableAlignment::Right => Self::Right,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ where
                 Strong => formatter.write_str(options.strong_token),
                 FootnoteDefinition(ref name) => {
                     state.padding.push("    ".into());
-                    write!(formatter, "[^{}]: ", name)
+                    write!(formatter, "[^{name}]: ")
                 }
                 Paragraph => Ok(()),
                 Heading {
@@ -644,13 +644,13 @@ where
             }
             Ok(())
         }
-        FootnoteReference(ref name) => write!(formatter, "[^{}]", name),
+        FootnoteReference(ref name) => write!(formatter, "[^{name}]"),
         TaskListMarker(checked) => {
             let check = if checked { "x" } else { " " };
-            write!(formatter, "[{}] ", check)
+            write!(formatter, "[{check}] ")
         }
-        InlineMath(ref text) => write!(formatter, "${}$", text),
-        DisplayMath(ref text) => write!(formatter, "$${}$$", text),
+        InlineMath(ref text) => write!(formatter, "${text}$"),
+        DisplayMath(ref text) => write!(formatter, "$${text}$$"),
     }
 }
 
@@ -674,9 +674,9 @@ where
     };
 
     if uri.contains(' ') {
-        write!(f, "]{}<{uri}>", separator, uri = uri)?;
+        write!(f, "]{separator}<{uri}>")?;
     } else {
-        write!(f, "]{}{uri}", separator, uri = uri)?;
+        write!(f, "]{separator}{uri}")?;
     }
     if !title.is_empty() {
         write!(f, " \"{title}\"", title = EscapeLinkTitle(title))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,7 +618,7 @@ where
                 shortcut_text.push_str(text);
             }
             if let Some(text_for_header) = state.text_for_header.as_mut() {
-                text_for_header.push_str(text)
+                text_for_header.push_str(text);
             }
             consume_newlines(formatter, state)?;
             state.last_was_text_without_trailing_newline = !text.ends_with('\n');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ where
 
     let last_was_text_without_trailing_newline = state.last_was_text_without_trailing_newline;
     state.last_was_text_without_trailing_newline = false;
-    match *event.borrow() {
+    match event.borrow() {
         Rule => {
             consume_newlines(formatter, state)?;
             if state.newlines_before_start < options.newlines_after_rule {
@@ -238,7 +238,7 @@ where
             }
             formatter.write_str("---")
         }
-        Code(ref text) => {
+        Code(text) => {
             if let Some(shortcut_text) = state.current_shortcut_text.as_mut() {
                 shortcut_text.push('`');
                 shortcut_text.push_str(text);
@@ -261,8 +261,8 @@ where
                 write!(formatter, "{backticks}{space}{text}{space}{backticks}")
             }
         }
-        Start(ref tag) => {
-            if let List(ref list_type) = *tag {
+        Start(tag) => {
+            if let List(list_type) = tag {
                 state.list_stack.push(*list_type);
                 if state.list_stack.len() > 1 && state.newlines_before_start < options.newlines_after_rest {
                     state.newlines_before_start = options.newlines_after_rest;
@@ -287,7 +287,7 @@ where
                     }
                     None => Ok(()),
                 },
-                Table(ref alignments) => {
+                Table(alignments) => {
                     state.table_alignments = alignments.iter().map(From::from).collect();
                     Ok(())
                 }
@@ -340,7 +340,7 @@ where
                 }
                 Emphasis => formatter.write_char(options.emphasis_token),
                 Strong => formatter.write_str(options.strong_token),
-                FootnoteDefinition(ref name) => {
+                FootnoteDefinition(name) => {
                     state.padding.push("    ".into());
                     write!(formatter, "[^{name}]: ")
                 }
@@ -401,7 +401,7 @@ where
                     }
                     formatter.write_char('\n').and(padding(formatter, &state.padding))
                 }
-                CodeBlock(CodeBlockKind::Fenced(ref info)) => {
+                CodeBlock(CodeBlockKind::Fenced(info)) => {
                     state.is_in_code_block = true;
                     let s = if !consumed_newlines {
                         formatter
@@ -431,7 +431,7 @@ where
                 DefinitionListDefinition => formatter.write_str(": "),
             }
         }
-        End(ref tag) => match tag {
+        End(tag) => match tag {
             TagEnd::Link => match state.link_stack.pop().unwrap() {
                 LinkCategory::AngleBracketed => formatter.write_char('>'),
                 LinkCategory::Shortcut { uri, title } => {
@@ -538,7 +538,7 @@ where
                     .push(state.text_for_header.take().unwrap_or_default());
                 Ok(())
             }
-            ref t @ (TagEnd::TableRow | TagEnd::TableHead) => {
+            t @ (TagEnd::TableRow | TagEnd::TableHead) => {
                 if state.newlines_before_start < options.newlines_after_rest {
                     state.newlines_before_start = options.newlines_after_rest;
                 }
@@ -613,7 +613,7 @@ where
         },
         HardBreak => formatter.write_str("  \n").and(padding(formatter, &state.padding)),
         SoftBreak => formatter.write_char('\n').and(padding(formatter, &state.padding)),
-        Text(ref text) => {
+        Text(text) => {
             if let Some(shortcut_text) = state.current_shortcut_text.as_mut() {
                 shortcut_text.push_str(text);
             }
@@ -628,11 +628,11 @@ where
                 &state.padding,
             )
         }
-        InlineHtml(ref text) => {
+        InlineHtml(text) => {
             consume_newlines(formatter, state)?;
             print_text_without_trailing_newline(text, formatter, &state.padding)
         }
-        Html(ref text) => {
+        Html(text) => {
             let mut lines = text.split('\n');
             if let Some(line) = lines.next() {
                 formatter.write_str(line)?;
@@ -644,13 +644,13 @@ where
             }
             Ok(())
         }
-        FootnoteReference(ref name) => write!(formatter, "[^{name}]"),
+        FootnoteReference(name) => write!(formatter, "[^{name}]"),
         TaskListMarker(checked) => {
-            let check = if checked { "x" } else { " " };
+            let check = if *checked { "x" } else { " " };
             write!(formatter, "[{check}] ")
         }
-        InlineMath(ref text) => write!(formatter, "${text}$"),
-        DisplayMath(ref text) => write!(formatter, "$${text}$$"),
+        InlineMath(text) => write!(formatter, "${text}$"),
+        DisplayMath(text) => write!(formatter, "$${text}$$"),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,12 +403,12 @@ where
                 }
                 CodeBlock(CodeBlockKind::Fenced(info)) => {
                     state.is_in_code_block = true;
-                    let s = if !consumed_newlines {
+                    let s = if consumed_newlines {
+                        Ok(())
+                    } else {
                         formatter
                             .write_char('\n')
                             .and_then(|()| padding(formatter, &state.padding))
-                    } else {
-                        Ok(())
                     };
 
                     s.and_then(|()| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,12 +465,12 @@ where
                     formatter.write_char('#')?;
                     formatter.write_str(&id_str)?;
                 }
-                for class in classes.iter() {
+                for class in &classes {
                     formatter.write_char(' ')?;
                     formatter.write_char('.')?;
                     formatter.write_str(class)?;
                 }
-                for (key, val) in attributes.iter() {
+                for (key, val) in &attributes {
                     formatter.write_char(' ')?;
                     formatter.write_str(key)?;
                     if let Some(val) = val {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ where
                     .push(state.text_for_header.take().unwrap_or_default());
                 Ok(())
             }
-            ref t @ TagEnd::TableRow | ref t @ TagEnd::TableHead => {
+            ref t @ (TagEnd::TableRow | TagEnd::TableHead) => {
                 if state.newlines_before_start < options.newlines_after_rest {
                     state.newlines_before_start = options.newlines_after_rest;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,20 +406,20 @@ where
                     let s = if !consumed_newlines {
                         formatter
                             .write_char('\n')
-                            .and_then(|_| padding(formatter, &state.padding))
+                            .and_then(|()| padding(formatter, &state.padding))
                     } else {
                         Ok(())
                     };
 
-                    s.and_then(|_| {
+                    s.and_then(|()| {
                         for _ in 0..options.code_block_token_count {
                             formatter.write_char(options.code_block_token)?;
                         }
                         Ok(())
                     })
-                    .and_then(|_| formatter.write_str(info))
-                    .and_then(|_| formatter.write_char('\n'))
-                    .and_then(|_| padding(formatter, &state.padding))
+                    .and_then(|()| formatter.write_str(info))
+                    .and_then(|()| formatter.write_char('\n'))
+                    .and_then(|()| padding(formatter, &state.padding))
                 }
                 HtmlBlock => Ok(()),
                 MetadataBlock(MetadataBlockKind::YamlStyle) => formatter.write_str("---\n"),

--- a/src/source_range.rs
+++ b/src/source_range.rs
@@ -62,7 +62,7 @@ where
         }
 
         if let (true, Some(range)) = (update_event_end_index, range) {
-            state.last_event_end_index = range.end
+            state.last_event_end_index = range.end;
         }
     }
     Ok(state)

--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -5,7 +5,7 @@ where
     F: fmt::Write,
 {
     for padding in p {
-        write!(f, "{}", padding)?;
+        write!(f, "{padding}")?;
     }
     Ok(())
 }
@@ -64,6 +64,6 @@ where
 pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {
     match l {
         None => "  ".into(),
-        Some(n) => format!("{}. ", n).chars().map(|_| ' ').collect::<String>().into(),
+        Some(n) => format!("{n}. ").chars().map(|_| ' ').collect::<String>().into(),
     }
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -16,7 +16,7 @@ mod code {
 
     #[test]
     fn code() {
-        assert_eq!(s(Code("foo\nbar".into())), "`foo\nbar`")
+        assert_eq!(s(Code("foo\nbar".into())), "`foo\nbar`");
     }
 }
 
@@ -27,7 +27,7 @@ mod rule {
 
     #[test]
     fn rule() {
-        assert_eq!(s(Rule), "---")
+        assert_eq!(s(Rule), "---");
     }
 }
 
@@ -45,7 +45,7 @@ mod start {
 
     #[test]
     fn paragraph() {
-        assert_eq!(s(Start(Paragraph)), "")
+        assert_eq!(s(Start(Paragraph)), "");
     }
     #[test]
     fn header1() {
@@ -57,7 +57,7 @@ mod start {
                 attrs: vec![]
             })),
             "# "
-        )
+        );
     }
     #[test]
     fn header2() {
@@ -69,7 +69,7 @@ mod start {
                 attrs: vec![]
             })),
             "## "
-        )
+        );
     }
     #[test]
     fn blockquote() {
@@ -94,31 +94,31 @@ mod start {
         assert_eq!(
             s(Start(CodeBlock(CodeBlockKind::Fenced("asdf".into())))),
             "\n````asdf\n"
-        )
+        );
     }
     #[test]
     fn list_unordered() {
-        assert_eq!(s(Start(List(None))), "")
+        assert_eq!(s(Start(List(None))), "");
     }
     #[test]
     fn list_ordered() {
-        assert_eq!(s(Start(List(Some(1)))), "")
+        assert_eq!(s(Start(List(Some(1)))), "");
     }
     #[test]
     fn item() {
-        assert_eq!(s(Start(Item)), "")
+        assert_eq!(s(Start(Item)), "");
     }
     #[test]
     fn footnote_definition() {
-        assert_eq!(s(Start(FootnoteDefinition("asdf".into()))), "[^asdf]: ")
+        assert_eq!(s(Start(FootnoteDefinition("asdf".into()))), "[^asdf]: ");
     }
     #[test]
     fn emphasis() {
-        assert_eq!(s(Start(Emphasis)), "*")
+        assert_eq!(s(Start(Emphasis)), "*");
     }
     #[test]
     fn strong() {
-        assert_eq!(s(Start(Strong)), "**")
+        assert_eq!(s(Start(Strong)), "**");
     }
     #[test]
     fn link() {
@@ -130,7 +130,7 @@ mod start {
                 id: "".into(),
             })),
             "["
-        )
+        );
     }
     #[test]
     fn link_without_title() {
@@ -142,7 +142,7 @@ mod start {
                 id: "".into()
             })),
             "["
-        )
+        );
     }
     #[test]
     fn image() {
@@ -154,7 +154,7 @@ mod start {
                 id: "".into()
             })),
             "!["
-        )
+        );
     }
     #[test]
     fn image_without_title() {
@@ -166,28 +166,28 @@ mod start {
                 id: "".into()
             })),
             "!["
-        )
+        );
     }
     #[test]
     fn table() {
-        assert_eq!(s(Start(Table(vec![Left, Center, Right, Alignment::None]))), "")
+        assert_eq!(s(Start(Table(vec![Left, Center, Right, Alignment::None]))), "");
     }
     #[test]
     fn table_head() {
-        assert_eq!(s(Start(TableHead)), "")
+        assert_eq!(s(Start(TableHead)), "");
     }
     #[test]
     fn table_row() {
-        assert_eq!(s(Start(TableRow)), "")
+        assert_eq!(s(Start(TableRow)), "");
     }
     #[test]
     fn table_cell() {
-        assert_eq!(s(Start(TableCell)), "|")
+        assert_eq!(s(Start(TableCell)), "|");
     }
 
     #[test]
     fn definition_list_definition() {
-        assert_eq!(s(Start(DefinitionListDefinition)), ": ")
+        assert_eq!(s(Start(DefinitionListDefinition)), ": ");
     }
 }
 
@@ -204,43 +204,43 @@ mod end {
             classes: Default::default(),
             attrs: Default::default(),
         };
-        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "## ")
+        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "## ");
     }
     #[test]
     fn paragraph() {
-        assert_eq!(s(End(TagEnd::Paragraph)), "")
+        assert_eq!(s(End(TagEnd::Paragraph)), "");
     }
     #[test]
     fn blockquote() {
-        assert_eq!(s(End(TagEnd::BlockQuote(None))), "")
+        assert_eq!(s(End(TagEnd::BlockQuote(None))), "");
     }
     #[test]
     fn codeblock() {
-        assert_eq!(s(End(TagEnd::CodeBlock)), "````")
+        assert_eq!(s(End(TagEnd::CodeBlock)), "````");
     }
     #[test]
     fn footnote_definition() {
-        assert_eq!(s(End(TagEnd::FootnoteDefinition)), "")
+        assert_eq!(s(End(TagEnd::FootnoteDefinition)), "");
     }
     #[test]
     fn emphasis() {
-        assert_eq!(s(End(TagEnd::Emphasis)), "*")
+        assert_eq!(s(End(TagEnd::Emphasis)), "*");
     }
     #[test]
     fn strong() {
-        assert_eq!(s(End(TagEnd::Strong)), "**")
+        assert_eq!(s(End(TagEnd::Strong)), "**");
     }
     #[test]
     fn list_unordered() {
-        assert_eq!(s(End(TagEnd::List(false))), "")
+        assert_eq!(s(End(TagEnd::List(false))), "");
     }
     #[test]
     fn list_ordered() {
-        assert_eq!(s(End(TagEnd::List(true))), "")
+        assert_eq!(s(End(TagEnd::List(true))), "");
     }
     #[test]
     fn item() {
-        assert_eq!(s(End(TagEnd::Item)), "")
+        assert_eq!(s(End(TagEnd::Item)), "");
     }
     #[test]
     fn link() {
@@ -250,7 +250,7 @@ mod end {
             title: "title".into(),
             id: "".into(),
         };
-        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "[](/uri \"title\")")
+        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "[](/uri \"title\")");
     }
     #[test]
     fn link_without_title() {
@@ -260,7 +260,7 @@ mod end {
             title: "".into(),
             id: "".into(),
         };
-        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "[](/uri)")
+        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "[](/uri)");
     }
     #[test]
     fn image() {
@@ -270,7 +270,7 @@ mod end {
             title: "title".into(),
             id: "".into(),
         };
-        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "![](/uri \"title\")")
+        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "![](/uri \"title\")");
     }
     #[test]
     fn image_without_title() {
@@ -280,41 +280,41 @@ mod end {
             title: "".into(),
             id: "".into(),
         };
-        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "![](/uri)")
+        assert_eq!(es([Start(tag.clone()), End(tag.to_end())]), "![](/uri)");
     }
     #[test]
     fn table() {
-        assert_eq!(s(End(TagEnd::Table)), "")
+        assert_eq!(s(End(TagEnd::Table)), "");
     }
     #[test]
     fn table_row() {
-        assert_eq!(s(End(TagEnd::TableRow)), "|")
+        assert_eq!(s(End(TagEnd::TableRow)), "|");
     }
     #[test]
     fn table_cell() {
-        assert_eq!(s(End(TagEnd::TableCell)), "")
+        assert_eq!(s(End(TagEnd::TableCell)), "");
     }
 }
 
 #[test]
 fn hardbreak() {
-    assert_eq!(s(Event::HardBreak), "  \n")
+    assert_eq!(s(Event::HardBreak), "  \n");
 }
 #[test]
 fn softbreak() {
-    assert_eq!(s(Event::SoftBreak), "\n")
+    assert_eq!(s(Event::SoftBreak), "\n");
 }
 #[test]
 fn html() {
-    assert_eq!(s(Event::Html("<table>hi</table>".into())), "<table>hi</table>")
+    assert_eq!(s(Event::Html("<table>hi</table>".into())), "<table>hi</table>");
 }
 #[test]
 fn text() {
-    assert_eq!(s(Event::Text("asdf".into())), "asdf")
+    assert_eq!(s(Event::Text("asdf".into())), "asdf");
 }
 #[test]
 fn footnote_reference() {
-    assert_eq!(s(Event::FootnoteReference("asdf".into())), "[^asdf]")
+    assert_eq!(s(Event::FootnoteReference("asdf".into())), "[^asdf]");
 }
 #[test]
 fn math() {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -319,14 +319,14 @@ fn footnote_reference() {
 #[test]
 fn math() {
     assert_eq!(
-        s(Event::InlineMath(r##"\sqrt{3x-1}+(1+x)^2"##.into())),
-        r##"$\sqrt{3x-1}+(1+x)^2$"##
+        s(Event::InlineMath(r"\sqrt{3x-1}+(1+x)^2".into())),
+        r"$\sqrt{3x-1}+(1+x)^2$"
     );
-    assert_eq!(s(Event::InlineMath(r##"\sqrt{\$4}"##.into())), r##"$\sqrt{\$4}$"##);
+    assert_eq!(s(Event::InlineMath(r"\sqrt{\$4}".into())), r"$\sqrt{\$4}$");
     assert_eq!(s(
       Event::DisplayMath(
-        r##"\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)"##.into()
+        r"\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)".into()
       )),
-        r##"$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$"##
+        r"$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$"
       );
 }

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -95,7 +95,7 @@ mod lazy_newlines {
                     newlines_before_start: 0,
                     ..Default::default()
                 }
-            )
+            );
         }
     }
 
@@ -112,7 +112,7 @@ mod lazy_newlines {
                     newlines_before_start: 1,
                     ..Default::default()
                 }
-            )
+            );
         }
     }
 
@@ -128,7 +128,7 @@ mod lazy_newlines {
                         ..Default::default()
                     }
                 )
-            )
+            );
         }
     }
 }
@@ -152,7 +152,7 @@ fn it_applies_newlines_before_start_before_text() {
                 ..Default::default()
             }
         )
-    )
+    );
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn it_applies_newlines_before_start_before_any_start_tag() {
                 ..Default::default()
             }
         )
-    )
+    );
 }
 
 mod padding {
@@ -201,7 +201,7 @@ mod padding {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 }
 
@@ -221,7 +221,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -235,7 +235,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -243,12 +243,12 @@ mod inline_elements {
         assert_eq!(
             fmts_both("a [^b]\n\n[^b]: this is\n    one footnote").0,
             "a [^b]\n\n[^b]: this is\n    one footnote",
-        )
+        );
     }
 
     #[test]
     fn autolinks_are_fully_resolved() {
-        assert_eq!(fmts_both("<http://a/b>").0, "<http://a/b>",)
+        assert_eq!(fmts_both("<http://a/b>").0, "<http://a/b>",);
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -276,7 +276,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -304,7 +304,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -318,7 +318,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -338,7 +338,7 @@ mod inline_elements {
                 newlines_before_start: 2,
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -357,7 +357,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -386,7 +386,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -402,7 +402,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -417,7 +417,7 @@ mod inline_elements {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -460,7 +460,7 @@ println!("Hello, world!");
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -486,7 +486,7 @@ println!("Hello, world!");
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 }
 
@@ -510,7 +510,7 @@ mod blockquote {
                 padding: vec![],
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -522,7 +522,7 @@ mod blockquote {
                 padding: vec![" > ".into()],
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -536,22 +536,22 @@ mod blockquote {
 
         assert_events_eq_both(s);
 
-        assert_eq!(fmts_both(s).0, "\n > \n > <table>\n > </table>\n > ")
+        assert_eq!(fmts_both(s).0, "\n > \n > <table>\n > </table>\n > ");
     }
 
     #[test]
     fn with_inlinehtml() {
-        assert_eq!(fmts_both(" > <br>").0, "\n > \n > <br>")
+        assert_eq!(fmts_both(" > <br>").0, "\n > \n > <br>");
     }
 
     #[test]
     fn with_plaintext_in_html() {
-        assert_eq!(fmts_both("<del>\n*foo*\n</del>").0, "<del>\n*foo*\n</del>")
+        assert_eq!(fmts_both("<del>\n*foo*\n</del>").0, "<del>\n*foo*\n</del>");
     }
 
     #[test]
     fn with_markdown_nested_in_html() {
-        assert_eq!(fmts_both("<del>\n\n*foo*\n\n</del>").0, "<del>\n\n*foo*\n\n</del>")
+        assert_eq!(fmts_both("<del>\n\n*foo*\n\n</del>").0, "<del>\n\n*foo*\n\n</del>");
     }
 
     #[test]
@@ -567,7 +567,7 @@ mod blockquote {
 
         assert_events_eq_both(s);
 
-        assert_eq!(fmts_both(s).0, "\n > \n > ````a\n > t1\n > t2\n > ````",)
+        assert_eq!(fmts_both(s).0, "\n > \n > ````a\n > t1\n > t2\n > ````",);
     }
 
     #[test]
@@ -584,7 +584,7 @@ mod blockquote {
 
         assert_events_eq_both(s);
 
-        assert_eq!(fmts_both(s).0, "\n > \n > a\n > \n >  > \n >  > b\n > \n > c",)
+        assert_eq!(fmts_both(s).0, "\n > \n > a\n > \n >  > \n >  > b\n > \n > c",);
     }
 
     #[test]
@@ -599,7 +599,7 @@ mod blockquote {
 
         assert_events_eq_both(s);
 
-        assert_eq!(fmts_both(s).0, "\n > \n >  > \n >  > foo\n >  > bar\n >  > baz",)
+        assert_eq!(fmts_both(s).0, "\n > \n >  > \n >  > foo\n >  > bar\n >  > baz",);
     }
 
     #[test]
@@ -623,7 +623,7 @@ mod blockquote {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -641,7 +641,7 @@ mod blockquote {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -665,7 +665,7 @@ mod blockquote {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -690,7 +690,7 @@ mod blockquote {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -714,7 +714,7 @@ mod blockquote {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -766,7 +766,7 @@ mod codeblock {
                 is_in_code_block: true,
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -780,7 +780,7 @@ mod codeblock {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -794,7 +794,7 @@ mod codeblock {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -808,7 +808,7 @@ mod codeblock {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -822,7 +822,7 @@ mod codeblock {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -862,7 +862,7 @@ mod table {
                 newlines_before_start: 2,
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -884,7 +884,7 @@ mod table {
                 table_headers: vec!["a".into(), "b".into()],
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -966,7 +966,7 @@ mod escapes {
     fn run_test_on_each_special_char(f: impl Fn(String, CowStr)) {
         for c in CmarkToCmarkOptions::default().special_characters().chars() {
             let s = format!(r#"\{special}"#, special = c);
-            f(s, c.to_string().into())
+            f(s, c.to_string().into());
         }
     }
 
@@ -987,7 +987,7 @@ mod escapes {
     fn it_recreates_escapes_for_known_special_characters_at_the_beginning_of_the_word() {
         run_test_on_each_special_char(|escaped_special_character, _| {
             assert_eq!(fmts_both(&escaped_special_character).0, escaped_special_character);
-        })
+        });
     }
 
     #[test]
@@ -1001,7 +1001,7 @@ mod escapes {
                 Event::Text("_".into()),
                 Event::End(TagEnd::Paragraph),
             ]
-        )
+        );
     }
 
     #[test]
@@ -1016,7 +1016,7 @@ mod escapes {
                 Event::Text("`".into()),
                 Event::End(TagEnd::Paragraph),
             ]
-        )
+        );
     }
 
     #[test]
@@ -1066,7 +1066,7 @@ mod escapes {
         assert_eq!(
             fmts("] a closing bracket does nothing").0,
             "\\] a closing bracket does nothing"
-        )
+        );
     }
 
     #[test]
@@ -1074,7 +1074,7 @@ mod escapes {
         assert_eq!(
             source_range_fmt::fmts("] a closing bracket does nothing").0,
             "] a closing bracket does nothing"
-        )
+        );
     }
 
     #[test]
@@ -1094,7 +1094,7 @@ mod escapes {
                 Event::Text("*".into()),
                 Event::End(TagEnd::Paragraph),
             ]
-        )
+        );
     }
 
     #[test]
@@ -1114,7 +1114,7 @@ mod escapes {
                 Event::End(TagEnd::Strong),
                 Event::End(TagEnd::Paragraph),
             ]
-        )
+        );
     }
 
     #[test]
@@ -1128,8 +1128,8 @@ mod escapes {
                     Event::Text(c.to_string().into()),
                     Event::End(TagEnd::Paragraph),
                 ]
-            )
-        })
+            );
+        });
     }
 }
 
@@ -1152,7 +1152,7 @@ mod list {
                 list_stack: vec![None],
                 ..Default::default()
             }
-        )
+        );
     }
 
     #[test]
@@ -1166,7 +1166,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1180,12 +1180,12 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
     fn unordered_ordered_unordered() {
-        assert_eq!(fmts_both("* a\n  1. b\n* c").0, "* a\n  1. b\n* c",)
+        assert_eq!(fmts_both("* a\n  1. b\n* c").0, "* a\n  1. b\n* c",);
     }
 
     #[test]
@@ -1199,7 +1199,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1213,7 +1213,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1226,7 +1226,7 @@ mod list {
         let original = "* a\n* b";
         let (s, _) = fmts_with_options(original, custom_options);
 
-        assert_eq!(s, "- a\n- b".to_string())
+        assert_eq!(s, "- a\n- b".to_string());
     }
 
     #[test]
@@ -1240,7 +1240,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1258,7 +1258,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1276,7 +1276,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1313,7 +1313,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]
@@ -1363,7 +1363,7 @@ mod list {
                     ..Default::default()
                 }
             )
-        )
+        );
     }
 
     #[test]

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -1006,7 +1006,7 @@ mod escapes {
 
     #[test]
     fn would_be_needed_for_single_backticks() {
-        let e: Vec<_> = Parser::new(r#"\`hi`"#).collect();
+        let e: Vec<_> = Parser::new(r"\`hi`").collect();
         assert_eq!(
             e,
             vec![
@@ -1022,8 +1022,8 @@ mod escapes {
     #[test]
     fn it_escapes_closing_square_brackets() {
         assert_eq!(
-            fmts_both(r#"[\[1\]](http://example.com)"#).0,
-            r#"[\[1\]](http://example.com)"#
+            fmts_both(r"[\[1\]](http://example.com)").0,
+            r"[\[1\]](http://example.com)"
         );
     }
 
@@ -1048,15 +1048,15 @@ mod escapes {
             r#"[link](http://example.com "\"link title\"")"#
         );
         assert_eq!(
-            fmts_both(r#"[link](http://example.com '\'link title\'')"#).0,
+            fmts_both(r"[link](http://example.com '\'link title\'')").0,
             r#"[link](http://example.com "'link title'")"#
         );
         assert_eq!(
-            fmts_both(r#"[link](http://example.com (\(link title\)))"#).0,
+            fmts_both(r"[link](http://example.com (\(link title\)))").0,
             r#"[link](http://example.com "(link title)")"#
         );
         assert_eq!(
-            fmts_both(r#"[link](http://example.com (你好👋))"#).0,
+            fmts_both(r"[link](http://example.com (你好👋))").0,
             r#"[link](http://example.com "你好👋")"#
         );
     }
@@ -1079,7 +1079,7 @@ mod escapes {
 
     #[test]
     fn make_special_characters_into_text_blocks() {
-        let e: Vec<_> = Parser::new(r#"hello\*there*and\*\*hello again\*\*"#).collect();
+        let e: Vec<_> = Parser::new(r"hello\*there*and\*\*hello again\*\*").collect();
         assert_eq!(
             e,
             vec![

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -62,7 +62,7 @@ fn assert_events_eq(s: &str) {
 
     let before_events = Parser::new_ext(s, Options::all());
     let after_events = Parser::new_ext(&buf, Options::all());
-    println!("{}", buf);
+    println!("{buf}");
     assert_eq!(before_events.collect::<Vec<_>>(), after_events.collect::<Vec<_>>());
 }
 
@@ -965,7 +965,7 @@ mod escapes {
 
     fn run_test_on_each_special_char(f: impl Fn(String, CowStr)) {
         for c in CmarkToCmarkOptions::default().special_characters().chars() {
-            let s = format!(r#"\{special}"#, special = c);
+            let s = format!(r#"\{c}"#);
             f(s, c.to_string().into());
         }
     }


### PR DESCRIPTION
fixes (but doesn't enforce) several pedantic clippy lints.

This is stacked on #80 to evidence the fact that these changes don't cause a jump in the MSRV. This should be rebased after #80 is merged