### PR TITLE
add MSRV check to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,3 +15,10 @@ jobs:
       run: |
         make tests
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-no-dev-deps
+      - uses: dtolnay/rust-toolchain@1.79.0
+      - run: cargo no-dev-deps check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://docs.rs/crate/pulldown-cmark-to-cmark"
 readme = "README.md"
 edition = "2018"
 include = ["src/*.rs", "LICENSE-APACHE", "README.md", "CHANGELOG.md"]
+rust-version = "1.79.0"
 
 [dependencies]
 pulldown-cmark = { version = "0.12.0", default-features = false }


### PR DESCRIPTION
Adds an MSRV check to CI.

Checking the MSRV ensures that the minimum compiler version for this project is not inadvertently (/unintentionally) bumped by changes to dependencies or syntax.

I found the MSRV using cargo-msrv. Using cargo-no-dev-deps ensures that the dev dependencies don't contribute to the MSRV