### PR TITLE
build: Lower MSRV to 1.71.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-no-dev-deps
-      - uses: dtolnay/rust-toolchain@1.79.0
-      - run: cargo no-dev-deps check
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack --rust-version --no-dev-deps check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://docs.rs/crate/pulldown-cmark-to-cmark"
 readme = "README.md"
 edition = "2018"
 include = ["src/*.rs", "LICENSE-APACHE", "README.md", "CHANGELOG.md"]
+# This follows the MSRV of `pulldown-cmark`
 rust-version = "1.71.1"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/crate/pulldown-cmark-to-cmark"
 readme = "README.md"
 edition = "2018"
 include = ["src/*.rs", "LICENSE-APACHE", "README.md", "CHANGELOG.md"]
-rust-version = "1.79.0"
+rust-version = "1.71.1"
 
 [dependencies]
 pulldown-cmark = { version = "0.12.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ cargo add pulldown-cmark-to-cmark
 [sc-example]: https://github.com/Byron/pulldown-cmark-to-cmark/blob/76667725b61be24890fbdfed5e7ecdb4c1ad1dc8/examples/stupicat.rs#L21
 [api]: https://docs.rs/crate/pulldown-cmark-to-cmark
 
+### Supported Rust Versions
+
+`pulldown-cmark-to-cmark` follows the MSRV (minimum supported rust version) policy of [`pulldown-cmark`]. The current MSRV is 1.71.1.
+
+[`pulldown-cmark`]: https://github.com/pulldown-cmark/pulldown-cmark
+
 ### Friends of this project
 
  * [**termbook**](https://github.com/Byron/termbook)


### PR DESCRIPTION
This project builds successfully with the MSRV of `pulldown-cmark`. Therefore we can lower `rust-version` to 1.71.1.

Add documentation for the current MSRV and that this project follows MSRV policy of `pulldown-cmark`.

Use `cargo hack` for MSRV CI job, to automatically install rustc according to `rust-version` and then execute `cargo check`.