### PR TITLE
feat!: improve code block round-tripping

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,13 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: tests
-      run: |
-        make tests
+      - uses: actions/checkout@v2
+      - name: cargo fmt
+        run: |
+          cargo fmt --check
+      - name: tests
+        run: |
+          make tests
 
   msrv:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,6 +610,7 @@ where
                 }
                 if last_was_text_without_trailing_newline {
                     formatter.write_char('\n')?;
+                    padding(formatter, &state.padding)?;
                 }
                 match state.code_block {
                     Some(CodeBlockKind::Fenced) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use pulldown_cmark::{
-    Alignment as TableAlignment, BlockQuoteKind, Event, HeadingLevel, LinkType, MetadataBlockKind, Tag, TagEnd,
+    Alignment as TableAlignment, BlockQuoteKind, Event, HeadingLevel, LinkType, MetadataBlockKind, Tag, TagEnd
 };
 
 mod source_range;
@@ -41,6 +41,12 @@ impl<'a> From<&'a TableAlignment> for Alignment {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CodeBlockKind {
+    Indented,
+    Fenced,
+}
+
 /// The state of the [`cmark_resume()`] and [`cmark_resume_with_options()`] functions.
 /// This does not only allow introspection, but enables the user
 /// to halt the serialization at any time, and resume it later.
@@ -60,7 +66,7 @@ pub struct State<'a> {
     /// The last seen text when serializing a header
     pub text_for_header: Option<String>,
     /// Is set while we are handling text in a code block
-    pub is_in_code_block: bool,
+    pub code_block: Option<CodeBlockKind>,
     /// True if the last event was text and the text does not have trailing newline. Used to inject additional newlines before code block end fence.
     pub last_was_text_without_trailing_newline: bool,
     /// True if the last event was a paragraph start. Used to escape spaces at start of line (prevent spurrious indented code).
@@ -81,6 +87,12 @@ pub struct State<'a> {
     /// It's used to see if the current event didn't capture some bytes because of a
     /// skipped-over backslash.
     pub last_event_end_index: usize,
+}
+
+impl State<'_> {
+    pub fn is_in_code_block(&self) -> bool {
+        self.code_block.is_some()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -232,7 +244,7 @@ where
     E: Borrow<Event<'a>>,
     F: fmt::Write,
 {
-    use pulldown_cmark::{CodeBlockKind, Event::*, Tag::*};
+    use pulldown_cmark::{Event::*, Tag::*};
 
     let last_was_text_without_trailing_newline = state.last_was_text_without_trailing_newline;
     state.last_was_text_without_trailing_newline = false;
@@ -446,15 +458,19 @@ where
                         formatter.write_char('\n').and(padding(formatter, &state.padding))
                     }
                 }
-                CodeBlock(CodeBlockKind::Indented) => {
-                    state.is_in_code_block = true;
-                    for _ in 0..options.code_block_token_count {
-                        formatter.write_char(options.code_block_token)?;
+                CodeBlock(pulldown_cmark::CodeBlockKind::Indented) => {
+                    state.code_block = Some(CodeBlockKind::Indented);
+                    state.padding.push("    ".into());
+                    if consumed_newlines {
+                        formatter.write_str("    ")
+                    } else {
+                        formatter
+                            .write_char('\n')
+                            .and_then(|()| padding(formatter, &state.padding))
                     }
-                    formatter.write_char('\n').and(padding(formatter, &state.padding))
                 }
-                CodeBlock(CodeBlockKind::Fenced(info)) => {
-                    state.is_in_code_block = true;
+                CodeBlock(pulldown_cmark::CodeBlockKind::Fenced(info)) => {
+                    state.code_block = Some(CodeBlockKind::Fenced);
                     let s = if consumed_newlines {
                         Ok(())
                     } else {
@@ -592,13 +608,21 @@ where
                 if state.newlines_before_start < options.newlines_after_codeblock {
                     state.newlines_before_start = options.newlines_after_codeblock;
                 }
-                state.is_in_code_block = false;
                 if last_was_text_without_trailing_newline {
                     formatter.write_char('\n')?;
                 }
-                for _ in 0..options.code_block_token_count {
-                    formatter.write_char(options.code_block_token)?;
+                match state.code_block {
+                    Some(CodeBlockKind::Fenced) => {
+                        for _ in 0..options.code_block_token_count {
+                            formatter.write_char(options.code_block_token)?;
+                        }
+                    }
+                    Some(CodeBlockKind::Indented) => {
+                        state.padding.pop();
+                    }
+                    None => {}
                 }
+                state.code_block = None;
                 Ok(())
             }
             TagEnd::HtmlBlock => {
@@ -728,7 +752,7 @@ where
             }
             state.last_was_text_without_trailing_newline = !text.ends_with('\n');
             print_text_without_trailing_newline(
-                &escape_leading_special_characters(text, state.is_in_code_block, options),
+                &escape_leading_special_characters(text, state.is_in_code_block(), options),
                 formatter,
                 &state.padding,
             )

--- a/src/source_range.rs
+++ b/src/source_range.rs
@@ -11,7 +11,7 @@ use super::{cmark_resume_one_event, fmt, Borrow, Event, Options, Range, State};
 ///     * Markdown source from which `event_and_ranges` are created.
 /// 1. **event_and_ranges**
 ///    * An iterator over [`Event`]-range pairs, for example as returned by [`pulldown_cmark::OffsetIter`].
-///     Must match what's provided in `source`.
+///      Must match what's provided in `source`.
 /// 1. **formatter**
 ///    * A format writer, can be a `String`.
 /// 1. **state**

--- a/src/source_range.rs
+++ b/src/source_range.rs
@@ -48,17 +48,17 @@ where
                 source.as_bytes().get(range.start.saturating_sub(1)) != Some(&b'\\')
             }
             _ => false,
-        } && !state.is_in_code_block;
+        } && !state.is_in_code_block();
         if prevent_escape_leading_special_characters {
             // Hack to not escape leading special characters.
-            state.is_in_code_block = true;
+            state.code_block = Some(crate::CodeBlockKind::Fenced);
         }
         cmark_resume_one_event(event, &mut formatter, &mut state, &options)?;
         if prevent_escape_leading_special_characters {
             // Assumption: this case only happens when `event` is `Text`,
             // so `state.is_in_code_block` should not be changed to `true`.
             // Also, `state.is_in_code_block` was `false`.
-            state.is_in_code_block = false;
+            state.code_block = None;
         }
 
         if let (true, Some(range)) = (update_event_end_index, range) {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -216,37 +216,49 @@ mod end {
     }
     #[test]
     fn codeblock() {
-        assert_eq!(es([Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))), End(TagEnd::CodeBlock)]), "\n````\n````");
+        assert_eq!(
+            es([
+                Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))),
+                End(TagEnd::CodeBlock)
+            ]),
+            "\n````\n````"
+        );
     }
     #[test]
     fn codeblock_in_list_item() {
-        assert_eq!(es([
-            Start(Tag::List(None)),
-            Start(Tag::Item),
-            Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))),
-            Text("foo".into()),
-            End(TagEnd::CodeBlock),
-            End(TagEnd::Item),
-            End(TagEnd::List(false)),
-            Start(Tag::Paragraph),
-            Text("bar".into()),
-            End(TagEnd::Paragraph),
-        ]), "* \n  ````\n  foo\n  ````\n\nbar");
+        assert_eq!(
+            es([
+                Start(Tag::List(None)),
+                Start(Tag::Item),
+                Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))),
+                Text("foo".into()),
+                End(TagEnd::CodeBlock),
+                End(TagEnd::Item),
+                End(TagEnd::List(false)),
+                Start(Tag::Paragraph),
+                Text("bar".into()),
+                End(TagEnd::Paragraph),
+            ]),
+            "* \n  ````\n  foo\n  ````\n\nbar"
+        );
     }
     #[test]
     fn codeblock_indented_in_list_item() {
-        assert_eq!(es([
-            Start(Tag::List(None)),
-            Start(Tag::Item),
-            Start(Tag::CodeBlock(CodeBlockKind::Indented)),
-            Text("foo".into()),
-            End(TagEnd::CodeBlock),
-            End(TagEnd::Item),
-            End(TagEnd::List(false)),
-            Start(Tag::Paragraph),
-            Text("bar".into()),
-            End(TagEnd::Paragraph),
-        ]), "* \n      foo\n      \n\nbar");
+        assert_eq!(
+            es([
+                Start(Tag::List(None)),
+                Start(Tag::Item),
+                Start(Tag::CodeBlock(CodeBlockKind::Indented)),
+                Text("foo".into()),
+                End(TagEnd::CodeBlock),
+                End(TagEnd::Item),
+                End(TagEnd::List(false)),
+                Start(Tag::Paragraph),
+                Text("bar".into()),
+                End(TagEnd::Paragraph),
+            ]),
+            "* \n      foo\n      \n\nbar"
+        );
     }
     #[test]
     fn footnote_definition() {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -192,7 +192,7 @@ mod start {
 }
 
 mod end {
-    use pulldown_cmark::{Event::*, HeadingLevel, LinkType::*, Tag, TagEnd};
+    use pulldown_cmark::{CodeBlockKind, Event::*, HeadingLevel, LinkType::*, Tag, TagEnd};
 
     use super::{es, s};
 
@@ -216,7 +216,7 @@ mod end {
     }
     #[test]
     fn codeblock() {
-        assert_eq!(s(End(TagEnd::CodeBlock)), "````");
+        assert_eq!(es([Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))), End(TagEnd::CodeBlock)]), "\n````\n````");
     }
     #[test]
     fn footnote_definition() {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -219,6 +219,36 @@ mod end {
         assert_eq!(es([Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))), End(TagEnd::CodeBlock)]), "\n````\n````");
     }
     #[test]
+    fn codeblock_in_list_item() {
+        assert_eq!(es([
+            Start(Tag::List(None)),
+            Start(Tag::Item),
+            Start(Tag::CodeBlock(CodeBlockKind::Fenced("".into()))),
+            Text("foo".into()),
+            End(TagEnd::CodeBlock),
+            End(TagEnd::Item),
+            End(TagEnd::List(false)),
+            Start(Tag::Paragraph),
+            Text("bar".into()),
+            End(TagEnd::Paragraph),
+        ]), "* \n  ````\n  foo\n  ````\n\nbar");
+    }
+    #[test]
+    fn codeblock_indented_in_list_item() {
+        assert_eq!(es([
+            Start(Tag::List(None)),
+            Start(Tag::Item),
+            Start(Tag::CodeBlock(CodeBlockKind::Indented)),
+            Text("foo".into()),
+            End(TagEnd::CodeBlock),
+            End(TagEnd::Item),
+            End(TagEnd::List(false)),
+            Start(Tag::Paragraph),
+            Text("bar".into()),
+            End(TagEnd::Paragraph),
+        ]), "* \n      foo\n      \n\nbar");
+    }
+    #[test]
     fn footnote_definition() {
         assert_eq!(s(End(TagEnd::FootnoteDefinition)), "");
     }

--- a/tests/fixtures/snapshots/stupicat-indented-code-block
+++ b/tests/fixtures/snapshots/stupicat-indented-code-block
@@ -3,3 +3,4 @@ codeblock:
     fn main() {
       println!("Hello, world!");
     }
+    

--- a/tests/fixtures/snapshots/stupicat-indented-code-block
+++ b/tests/fixtures/snapshots/stupicat-indented-code-block
@@ -1,7 +1,5 @@
 codeblock:
 
-````
-fn main() {
-  println!("Hello, world!");
-}
-````
+    fn main() {
+      println!("Hello, world!");
+    }

--- a/tests/fixtures/snapshots/stupicat-lists-nested-output
+++ b/tests/fixtures/snapshots/stupicat-lists-nested-output
@@ -19,8 +19,7 @@
 
 1. list paragraph 1
    
-   ````
-   code sample
-   ````
+       code sample
+       
 
 1. list paragraph 2

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -791,7 +791,7 @@ mod codeblock {
         assert_eq!(
             fmte(&[Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced("s".into()))),]).1,
             State {
-                is_in_code_block: true,
+                code_block: Some(pulldown_cmark_to_cmark::CodeBlockKind::Fenced),
                 ..Default::default()
             }
         );
@@ -864,6 +864,34 @@ mod codeblock {
         let (s, _) = fmts_with_options(original, custom_options);
 
         assert_eq!(s, "\n~~~~hi\nsome\ntext\n~~~~".to_string());
+    }
+
+    #[test]
+    fn indented() {
+        assert_eq!(
+            fmts_both("    first\n    second\nthird"),
+            (
+                "\n    first\n    second\n    \n\nthird".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn html_indented() {
+        assert_eq!(
+            fmts_both("  <!-- foo -->\n\n    <!-- foo -->"),
+            (
+                "  <!-- foo -->\n\n    <!-- foo -->\n".into(),
+                State {
+                    newlines_before_start: 2,
+                    ..Default::default()
+                }
+            )
+        );
     }
 }
 

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -885,7 +885,7 @@ mod codeblock {
         assert_eq!(
             fmts_both("  <!-- foo -->\n\n    <!-- foo -->"),
             (
-                "  <!-- foo -->\n\n    <!-- foo -->\n".into(),
+                "  <!-- foo -->\n\n    <!-- foo -->\n    ".into(),
                 State {
                     newlines_before_start: 2,
                     ..Default::default()


### PR DESCRIPTION
This raises the number of passing spec tests from 459 to 473.

Fixes #69