### PR TITLE
Drasticly improve escaping `!`, `#`, and `|`

### DIFF
--- a/src/source_range.rs
+++ b/src/source_range.rs
@@ -39,6 +39,9 @@ where
     for (event, range) in event_and_ranges {
         let update_event_end_index = !matches!(*event.borrow(), Event::Start(_));
         let prevent_escape_leading_special_characters = match (&range, event.borrow()) {
+            // Headers and tables can have special characters that aren't at the start
+            // of the line, because headers end with `#` and tables have pipes in the middle.
+            _ if state.current_heading.is_some() || !state.table_alignments.is_empty() => false,
             // IMPORTANT: Any changes that allow anything other than `Text`
             // breaks the assumption below.
             (Some(range), Event::Text(_)) => {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -41,7 +41,7 @@ mod start {
         Tag::*,
     };
 
-    use super::s;
+    use super::{es, s};
 
     #[test]
     fn paragraph() {
@@ -177,6 +177,18 @@ mod start {
     #[test]
     fn table_cell() {
         assert_eq!(s(Start(TableCell)), "|");
+    }
+    #[test]
+    fn table_pipe() {
+        assert_eq!(
+            es([
+                Start(Table(vec![Left, Center, Right, Alignment::None])),
+                Start(TableHead),
+                Start(TableCell),
+                Text("a|b".into()),
+            ]),
+            r"|a\|b"
+        );
     }
 
     #[test]

--- a/tests/source_range_fmt.rs
+++ b/tests/source_range_fmt.rs
@@ -1,6 +1,6 @@
 // Copied from `fmt.rs`.
 
-use pulldown_cmark::{Options, Parser};
+use pulldown_cmark::{utils::TextMergeStream, Options, Parser};
 use pulldown_cmark_to_cmark::{
     cmark_resume_with_source_range_and_options, cmark_with_source_range, Options as CmarkToCmarkOptions, State,
 };
@@ -50,7 +50,7 @@ pub fn assert_events_eq(s: &str) {
     )
     .unwrap();
 
-    let before_events = Parser::new_ext(s, Options::all());
-    let after_events = Parser::new_ext(&buf, Options::all());
+    let before_events = TextMergeStream::new(Parser::new_ext(s, Options::all()));
+    let after_events = TextMergeStream::new(Parser::new_ext(&buf, Options::all()));
     assert_eq!(before_events.collect::<Vec<_>>(), after_events.collect::<Vec<_>>());
 }

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -38,9 +38,12 @@ fn collect_test_case<'a>(events: &mut impl Iterator<Item = Event<'a>>) -> Option
 
 fn test_roundtrip(original: &str, expected: &str) -> bool {
     let opts = Options::empty();
-    let event_list = TextMergeStream::new(Parser::new_ext(original, opts)).collect::<Vec<_>>();
+    let event_list = Parser::new_ext(original, opts).collect::<Vec<_>>();
     let mut regen_str = String::new();
     cmark(event_list.iter().cloned(), &mut regen_str).expect("Regeneration failure");
+    // text events should be merged before comparing two event lists for equivalence.
+    // you don't need to merge them before feeding them into `cmark`.
+    let event_list: Vec<Event<'_>> = TextMergeStream::new(event_list.into_iter()).collect();
     let event_list_2 = TextMergeStream::new(Parser::new_ext(&regen_str, opts)).collect::<Vec<_>>();
     let event_count = event_list.len();
     let event_count_2 = event_list_2.len();


### PR DESCRIPTION
Raises spec tests from 578 to 580. It handles cases that look like these

    Link, not image: \![a](b)

    This header ends with hashes, not an ATX trailer ###
    ====================================================

    | a \| b | a \| c |
    |--------|--------|