### PR TITLE
Alternative approach for #91 with custom error type

### DIFF
--- a/src/source_range.rs
+++ b/src/source_range.rs
@@ -1,4 +1,4 @@
-use super::{cmark_resume_one_event, fmt, Borrow, Event, Options, Range, State};
+use super::{cmark_resume_one_event, fmt, Borrow, Error, Event, Options, Range, State};
 
 /// Serialize a stream of [pulldown-cmark-Events][Event] while preserving the escape characters in `source`.
 /// Each input [Event] is accompanied by an optional [Range] that maps it back to the `source` string.
@@ -22,14 +22,17 @@ use super::{cmark_resume_one_event, fmt, Borrow, Event, Options, Range, State};
 ///
 /// *Returns* the [`State`] of the serialization on success. You can use it as initial state in the
 /// next call if you are halting event serialization.
-/// *Errors* are only happening if the underlying buffer fails, which is unlikely.
+///
+/// *Errors* if the underlying buffer fails (which is unlikely) or if the [`Event`] stream
+/// iterated over by `event_and_ranges` cannot ever be produced by deserializing valid Markdown.
+/// Each failure mode corresponds to one of [`Error`]'s variants.
 pub fn cmark_resume_with_source_range_and_options<'a, I, E, F>(
     event_and_ranges: I,
     source: &'a str,
     mut formatter: F,
     state: Option<State<'a>>,
     options: Options<'_>,
-) -> Result<State<'a>, fmt::Error>
+) -> Result<State<'a>, Error>
 where
     I: Iterator<Item = (E, Option<Range<usize>>)>,
     E: Borrow<Event<'a>>,
@@ -77,7 +80,7 @@ pub fn cmark_resume_with_source_range<'a, I, E, F>(
     source: &'a str,
     formatter: F,
     state: Option<State<'a>>,
-) -> Result<State<'a>, fmt::Error>
+) -> Result<State<'a>, Error>
 where
     I: Iterator<Item = (E, Option<Range<usize>>)>,
     E: Borrow<Event<'a>>,
@@ -92,7 +95,7 @@ pub fn cmark_with_source_range_and_options<'a, I, E, F>(
     source: &'a str,
     mut formatter: F,
     options: Options<'_>,
-) -> Result<State<'a>, fmt::Error>
+) -> Result<State<'a>, Error>
 where
     I: Iterator<Item = (E, Option<Range<usize>>)>,
     E: Borrow<Event<'a>>,
@@ -113,7 +116,7 @@ pub fn cmark_with_source_range<'a, I, E, F>(
     event_and_ranges: I,
     source: &'a str,
     mut formatter: F,
-) -> Result<State<'a>, fmt::Error>
+) -> Result<State<'a>, Error>
 where
     I: Iterator<Item = (E, Option<Range<usize>>)>,
     E: Borrow<Event<'a>>,

--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -50,19 +50,15 @@ pub fn print_text_without_trailing_newline<F>(t: &str, f: &mut F, p: &[Cow<'_, s
 where
     F: fmt::Write,
 {
-    if t.contains('\n') {
-        let line_count = t.split('\n').count();
-        for (tid, token) in t.split('\n').enumerate() {
-            f.write_str(token).and(if tid + 1 == line_count {
-                Ok(())
-            } else {
-                f.write_char('\n').and(padding(f, p))
-            })?;
+    let line_count = t.split('\n').count();
+    for (tid, token) in t.split('\n').enumerate() {
+        f.write_str(token)?;
+        if tid + 1 < line_count {
+            f.write_char('\n')?;
+            padding(f, p)?;
         }
-        Ok(())
-    } else {
-        f.write_str(t)
     }
+    Ok(())
 }
 
 pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {

--- a/tests/integrate/main.rs
+++ b/tests/integrate/main.rs
@@ -3,6 +3,37 @@ mod fmt;
 mod spec;
 
 #[cfg(test)]
+mod fuzzed {
+    use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd};
+    use pulldown_cmark_to_cmark::{cmark, Error};
+
+    #[test]
+    fn cmark_with_invalid_event_stream() {
+        let events = [
+            Event::Start(Tag::Heading {
+                level: HeadingLevel::H2,
+                id: None,
+                classes: vec![],
+                attrs: vec![],
+            }),
+            Event::Start(Tag::Heading {
+                level: HeadingLevel::H2,
+                id: None,
+                classes: vec![],
+                attrs: vec![],
+            }),
+            Event::Text(pulldown_cmark::CowStr::Borrowed("hello")),
+            Event::End(TagEnd::Heading(HeadingLevel::H2)),
+            Event::End(TagEnd::Heading(HeadingLevel::H2)),
+        ];
+        assert!(matches!(
+            cmark(events.iter(), String::new()),
+            Err(Error::UnexpectedEvent)
+        ));
+    }
+}
+
+#[cfg(test)]
 mod calculate_code_block_token_count {
     use pulldown_cmark::{CodeBlockKind, CowStr, Event, Tag, TagEnd};
     use pulldown_cmark_to_cmark::calculate_code_block_token_count;

--- a/tests/integrate/main.rs
+++ b/tests/integrate/main.rs
@@ -1,32 +1,6 @@
 mod display;
 mod fmt;
 mod spec;
-mod fuzzed {
-    use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd};
-    use pulldown_cmark_to_cmark::cmark_resume;
-
-    #[test]
-    fn cmark_resume_with_options_does_not_panic() {
-        let events = [
-            Event::Start(Tag::Heading {
-                level: HeadingLevel::H2,
-                id: None,
-                classes: vec![],
-                attrs: vec![],
-            }),
-            Event::Start(Tag::Heading {
-                level: HeadingLevel::H2,
-                id: None,
-                classes: vec![],
-                attrs: vec![],
-            }),
-            Event::Text(pulldown_cmark::CowStr::Borrowed("(")),
-            Event::End(TagEnd::Heading(HeadingLevel::H2)),
-            Event::End(TagEnd::Heading(HeadingLevel::H2)),
-        ];
-        let _ = cmark_resume(events.iter(), String::new(), None);
-    }
-}
 
 #[cfg(test)]
 mod calculate_code_block_token_count {


### PR DESCRIPTION
This implements what I outlined in [this comment](https://github.com/Byron/pulldown-cmark-to-cmark/issues/91#issuecomment-2543059387).

One thought/remark I have is that I would have liked to add some information to the `UnexpectedEvent` variant, in particular:

```rs
pub enum CmarkError<'a> {
  FormatFailed(fmt::Error),
  UnexpectedEvent(Event<'a>),
}
```

I could make this work, but then I realized that it would most certainly break all consumers of this library, even those that treat the error as a `Box<dyn std::error::Error>`. This is because, if the `Event`s are local to the function that calls `cmark()`, that function cannot simply propagate the error to the caller (e.g. via `?`), since then it would outlive the events. The "stupicat" example would also fail to build for this exact reason.

So, I decided to not overdo it. Hope it's okay!