### PR TITLE
refactor: Add helper to factor out newline + padding pattern

### DIFF
--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -73,7 +73,7 @@ pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {
 ///
 /// [`write_padded_newline()`] takes care of writing both a newline character,
 /// and the appropriate padding characters, abstracting over the need to
-/// carefully pair writing of a newline with writing of padding characters.
+/// carefully pair those actions.
 ///
 /// # Purpose
 ///
@@ -84,7 +84,7 @@ pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {
 /// >·A block quote with an embedded list:
 /// >·
 /// >·* This is a list item that itself contains
-/// >···multiple lines and paragraph of content.
+/// >···multiple lines and paragraphs of content.
 /// >···
 /// >···Second paragraph.
 /// ```
@@ -95,7 +95,7 @@ pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {
 /// list item is indented.
 ///
 /// Concretely, a call to [`write_padded_newline()`] after the first line in the
-/// paragraph of the list item would write `">···"`.
+/// paragraph of the list item would write `"\n>···"`.
 pub(crate) fn write_padded_newline(formatter: &mut impl fmt::Write, state: &State<'_>) -> Result<(), fmt::Error> {
     formatter.write_char('\n')?;
     padding(formatter, &state.padding)?;

--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -67,3 +67,37 @@ pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {
         Some(n) => format!("{n}. ").chars().map(|_| ' ').collect::<String>().into(),
     }
 }
+
+/// Write a newline followed by the current [`State.padding`][State::padding]
+/// text that indents the current nested content.
+///
+/// [`write_padded_newline()`] takes care of writing both a newline character,
+/// and the appropriate padding characters, abstracting over the need to
+/// carefully pair writing of a newline with writing of padding characters.
+///
+/// # Purpose
+///
+/// Consider a scenario where we're trying to write out the following Markdown
+/// (space indents visualized as '·'):
+///
+/// ```markdown
+/// >·A block quote with an embedded list:
+/// >·
+/// >·* This is a list item that itself contains
+/// >···multiple lines and paragraph of content.
+/// >···
+/// >···Second paragraph.
+/// ```
+///
+/// Each line of output within the block quote needs to include the text `">·"`
+/// at the beginning of the line. Additionally, within the list, each line
+/// _also_ needs to start with `"··"` spaces so that the content of the
+/// list item is indented.
+///
+/// Concretely, a call to [`write_padded_newline()`] after the first line in the
+/// paragraph of the list item would write `">···"`.
+pub(crate) fn write_padded_newline(formatter: &mut impl fmt::Write, state: &State<'_>) -> Result<(), fmt::Error> {
+    formatter.write_char('\n')?;
+    padding(formatter, &state.padding)?;
+    Ok(())
+}

--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -68,7 +68,7 @@ pub fn padding_of(l: Option<u64>) -> Cow<'static, str> {
     }
 }
 
-/// Write a newline followed by the current [`State.padding`][State::padding]
+/// Write a newline followed by the current [`State::padding`]
 /// text that indents the current nested content.
 ///
 /// [`write_padded_newline()`] takes care of writing both a newline character,


### PR DESCRIPTION
Hey 👋, big fan and first-time contributor to this project🙂

I'm building a Markdown editor that incorporates `pulldown-cmark-to-cmark`, and thought it might be time that I try to contribute some effort back to this project (and perhaps improve on a few issues I've run into). I've found that a great way to learn a new codebase is to start with making some small improvements that don't try to change behavior, so that's what I'm starting with here 🙂

Please let me know if you'd like anything changed with this patch, or if you'd prefer I start with some other kind of change.

<details>

<summary>
If you happen to be interested in how I'm putting this project to use, click here to read a bit about that.
</summary>
<br/>

I use `pulldown-cmark-to-cmark` as part of [`markdown-ast`](https://crates.io/crates/markdown-ast), which supports converting `Markdown → Events → an AST` (and back again). I've developing that project as part of a quest to build a ["WYSISYG"](https://en.wikipedia.org/wiki/WYSIWYG)-style editor for Markdown within Wolfram notebooks.

Overall `pulldown-cmark-to-cmark` works great for that use case, but since my flow is `Foo.md → <edit file> → Foo.md`, I care especially that the Markdown "round-trips" as well as possible.

I understand that round-tripping of Markdown is likely quite difficult in general, but I'm hoping that, over time, a few adjustments and additional configuration knobs on `pulldown-cmark-to-cmark` can make it tractable for certain use cases.

For example, if the `Foo.md` being round-tripped is restricted by Markdown linting that runs in CI (enforcing things like consistent use of '*' vs '-' for bulletted lists, exact numbers of blank lines between paragraphs, etc.), then it is much easier to imagine `pulldown-cmark-to-cmark` generating output that conforms to particular, fixed rules.

I'm also hoping to eventually refactor my [`clap-markdown`](https://crates.io/crates/clap-markdown) crate to use `pulldown-cmark-to-cmark` instead of bespoke (error prone), manual generation of a Markdown string.
</details>

---

After writing a newline into the generated Markdown output to start a new line of output, it is (almost) always necessary to output the "padding" characters used to indent the content at the current location in the document.

Since writing a newline and writing the padding are always paired, factoring them out into a function should help with readability and consistency in performing this minor two-step dance correctly.
