### PR TITLE
refactor: Use `write_padded_string()` in a couple additional places (Part 2/X)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,15 +868,12 @@ where
                 }
             }
             state.last_was_text_without_trailing_newline = !text.ends_with('\n');
-            print_text_without_trailing_newline(
-                &escape_special_characters(text, state, options),
-                formatter,
-                &state.padding,
-            )
+            let escaped_text = escape_special_characters(text, state, options);
+            print_text_without_trailing_newline(&escaped_text, formatter, &state)
         }
         InlineHtml(text) => {
             consume_newlines(formatter, state)?;
-            print_text_without_trailing_newline(text, formatter, &state.padding)
+            print_text_without_trailing_newline(text, formatter, &state)
         }
         Html(text) => {
             let mut lines = text.split('\n');


### PR DESCRIPTION
This is a follow-up to #98, that uses the `write_padded_string()` helper in a handful of places I missed in that PR. 

Additionally, while in the neighhborhood, add `pub(crate)` to the other text_modifications.rs private helpers,
as [we discussed yesterday](https://github.com/Byron/pulldown-cmark-to-cmark/pull/98#discussion_r1959149931) 🙂. These being marked as `pub` is misleading since the `text_modifications` module is
not actually externally public, and these functions are never re-exported publicly.

---

Because you said:

> Thanks for offering. If you happen to keep contributing something else you could U-Boot that, but no need for a PR just for that.

I tucked the `pub(crate)` change into this PR instead of making a dedicated PR just for that small change. I am hoping to keep contributing 🙂, and as the `Part 2/X` in the title might suggest, I've got a couple of small changes queued up :).

I'll try to balance keeping each individual change as small as possible (to make review feel easy and able to fit into whatever time you might have available), will avoiding PRs that are _so_ small that the overhead of reviewing them and merging doesn't feel worth while. As a maintainer myself over at [modular/mojo](https://github.com/modular/mojo), I know the pain of reviewing over-large PRs.

But I'm happy to adjust to whatever size/style works best for you. Please don't hesitate to suggest any changes to how I'm hoping to contribute here; my goal is to make it as smooth as possible for the maintainers to review my work here🙂 

