### PR TITLE
refactor: Move and group related code (Part 4/X)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,10 +251,6 @@ impl From<fmt::Error> for Error {
     }
 }
 
-//======================================
-// Public API Functions
-//======================================
-
 /// As [`cmark_with_options()`], but with default [`Options`].
 pub fn cmark<'a, I, E, F>(events: I, mut formatter: F) -> Result<State<'a>, Error>
 where

--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -1,70 +1,11 @@
-use super::{fmt, Cow, Options, State};
+use super::{
+    fmt::{self, Write},
+    Cow, LinkType, Options, State,
+};
 
-pub(crate) fn padding<F>(f: &mut F, p: &[Cow<'_, str>]) -> fmt::Result
-where
-    F: fmt::Write,
-{
-    for padding in p {
-        write!(f, "{padding}")?;
-    }
-    Ok(())
-}
-pub(crate) fn consume_newlines<F>(f: &mut F, s: &mut State<'_>) -> fmt::Result
-where
-    F: fmt::Write,
-{
-    while s.newlines_before_start != 0 {
-        s.newlines_before_start -= 1;
-        write_padded_newline(f, s)?;
-    }
-    Ok(())
-}
-
-pub(crate) fn escape_special_characters<'a>(t: &'a str, state: &State<'a>, options: &Options<'a>) -> Cow<'a, str> {
-    if state.is_in_code_block() || t.is_empty() {
-        return Cow::Borrowed(t);
-    }
-
-    let first = t.chars().next().expect("at least one char");
-    let first_special = options.special_characters().contains(first);
-    let ends_with_special =
-        (state.next_is_link_like && t.ends_with("!")) || (state.current_heading.is_some() && t.ends_with("#"));
-    let table_contains_pipe = !state.table_alignments.is_empty() && t.contains("|");
-    if first_special || ends_with_special || table_contains_pipe {
-        let mut s = String::with_capacity(t.len() + 1);
-        for (i, c) in t.char_indices() {
-            if (i == 0 && first_special) || (i == t.len() - 1 && ends_with_special) || (c == '|' && table_contains_pipe)
-            {
-                s.push('\\');
-            }
-            s.push(c);
-        }
-        Cow::Owned(s)
-    } else {
-        Cow::Borrowed(t)
-    }
-}
-
-pub(crate) fn print_text_without_trailing_newline<F>(t: &str, f: &mut F, state: &State<'_>) -> fmt::Result
-where
-    F: fmt::Write,
-{
-    let line_count = t.split('\n').count();
-    for (tid, token) in t.split('\n').enumerate() {
-        f.write_str(token)?;
-        if tid + 1 < line_count {
-            write_padded_newline(f, state)?;
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn padding_of(l: Option<u64>) -> Cow<'static, str> {
-    match l {
-        None => "  ".into(),
-        Some(n) => format!("{n}. ").chars().map(|_| ' ').collect::<String>().into(),
-    }
-}
+//======================================
+// Padding and newlines
+//======================================
 
 /// Write a newline followed by the current [`State::padding`]
 /// text that indents the current nested content.
@@ -98,4 +39,183 @@ pub(crate) fn write_padded_newline(formatter: &mut impl fmt::Write, state: &Stat
     formatter.write_char('\n')?;
     padding(formatter, &state.padding)?;
     Ok(())
+}
+
+pub(crate) fn padding<F>(f: &mut F, p: &[Cow<'_, str>]) -> fmt::Result
+where
+    F: fmt::Write,
+{
+    for padding in p {
+        write!(f, "{padding}")?;
+    }
+    Ok(())
+}
+pub(crate) fn consume_newlines<F>(f: &mut F, s: &mut State<'_>) -> fmt::Result
+where
+    F: fmt::Write,
+{
+    while s.newlines_before_start != 0 {
+        s.newlines_before_start -= 1;
+        write_padded_newline(f, s)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn print_text_without_trailing_newline<F>(t: &str, f: &mut F, state: &State<'_>) -> fmt::Result
+where
+    F: fmt::Write,
+{
+    let line_count = t.split('\n').count();
+    for (tid, token) in t.split('\n').enumerate() {
+        f.write_str(token)?;
+        if tid + 1 < line_count {
+            write_padded_newline(f, state)?;
+        }
+    }
+    Ok(())
+}
+
+//======================================
+// Special Markdown element helpers
+//======================================
+
+pub(crate) fn list_item_padding_of(l: Option<u64>) -> Cow<'static, str> {
+    match l {
+        None => "  ".into(),
+        Some(n) => format!("{n}. ").chars().map(|_| ' ').collect::<String>().into(),
+    }
+}
+
+//
+// Links
+//
+
+pub(crate) fn close_link<F>(uri: &str, title: &str, f: &mut F, link_type: LinkType) -> fmt::Result
+where
+    F: fmt::Write,
+{
+    let needs_brackets = {
+        let mut depth = 0;
+        for b in uri.bytes() {
+            match b {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                b' ' => {
+                    depth += 1;
+                    break;
+                }
+                _ => {}
+            }
+            if depth > 3 {
+                break;
+            }
+        }
+        depth != 0
+    };
+    let separator = match link_type {
+        LinkType::Shortcut => ": ",
+        _ => "(",
+    };
+
+    if needs_brackets {
+        write!(f, "]{separator}<{uri}>")?;
+    } else {
+        write!(f, "]{separator}{uri}")?;
+    }
+    if !title.is_empty() {
+        write!(f, " \"{title}\"", title = EscapeLinkTitle(title))?;
+    }
+    if link_type != LinkType::Shortcut {
+        f.write_char(')')?;
+    }
+
+    Ok(())
+}
+
+struct EscapeLinkTitle<'a>(&'a str);
+
+/// Writes a link title with double quotes escaped.
+/// See https://spec.commonmark.org/0.30/#link-title for the rules around
+/// link titles and the characters they may contain.
+impl fmt::Display for EscapeLinkTitle<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for c in self.0.chars() {
+            match c {
+                '"' => f.write_str(r#"\""#)?,
+                '\\' => f.write_str(r"\\")?,
+                c => f.write_char(c)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+//======================================
+// Escaping
+//======================================
+
+pub(crate) fn escape_special_characters<'a>(t: &'a str, state: &State<'a>, options: &Options<'a>) -> Cow<'a, str> {
+    if state.is_in_code_block() || t.is_empty() {
+        return Cow::Borrowed(t);
+    }
+
+    let first = t.chars().next().expect("at least one char");
+    let first_special = options.special_characters().contains(first);
+    let ends_with_special =
+        (state.next_is_link_like && t.ends_with("!")) || (state.current_heading.is_some() && t.ends_with("#"));
+    let table_contains_pipe = !state.table_alignments.is_empty() && t.contains("|");
+    if first_special || ends_with_special || table_contains_pipe {
+        let mut s = String::with_capacity(t.len() + 1);
+        for (i, c) in t.char_indices() {
+            if (i == 0 && first_special) || (i == t.len() - 1 && ends_with_special) || (c == '|' && table_contains_pipe)
+            {
+                s.push('\\');
+            }
+            s.push(c);
+        }
+        Cow::Owned(s)
+    } else {
+        Cow::Borrowed(t)
+    }
+}
+
+//======================================
+// General-purpose string utilities
+//======================================
+
+pub(crate) fn max_consecutive_chars(text: &str, search: char) -> usize {
+    let mut in_search_chars = false;
+    let mut max_count = 0;
+    let mut cur_count = 0;
+
+    for ch in text.chars() {
+        if ch == search {
+            cur_count += 1;
+            in_search_chars = true;
+        } else if in_search_chars {
+            max_count = max_count.max(cur_count);
+            cur_count = 0;
+            in_search_chars = false;
+        }
+    }
+    max_count.max(cur_count)
+}
+
+#[cfg(test)]
+mod max_consecutive_chars {
+    use super::max_consecutive_chars;
+
+    #[test]
+    fn happens_in_the_entire_string() {
+        assert_eq!(
+            max_consecutive_chars("``a```b``", '`'),
+            3,
+            "the highest seen consecutive segment of backticks counts"
+        );
+        assert_eq!(
+            max_consecutive_chars("```a``b`", '`'),
+            3,
+            "it can't be downgraded later"
+        );
+    }
 }

--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -3,10 +3,6 @@ use super::{
     Cow, LinkType, Options, State,
 };
 
-//======================================
-// Padding and newlines
-//======================================
-
 /// Write a newline followed by the current [`State::padding`]
 /// text that indents the current nested content.
 ///
@@ -75,20 +71,12 @@ where
     Ok(())
 }
 
-//======================================
-// Special Markdown element helpers
-//======================================
-
 pub(crate) fn list_item_padding_of(l: Option<u64>) -> Cow<'static, str> {
     match l {
         None => "  ".into(),
         Some(n) => format!("{n}. ").chars().map(|_| ' ').collect::<String>().into(),
     }
 }
-
-//
-// Links
-//
 
 pub(crate) fn close_link<F>(uri: &str, title: &str, f: &mut F, link_type: LinkType) -> fmt::Result
 where
@@ -150,10 +138,6 @@ impl fmt::Display for EscapeLinkTitle<'_> {
     }
 }
 
-//======================================
-// Escaping
-//======================================
-
 pub(crate) fn escape_special_characters<'a>(t: &'a str, state: &State<'a>, options: &Options<'a>) -> Cow<'a, str> {
     if state.is_in_code_block() || t.is_empty() {
         return Cow::Borrowed(t);
@@ -178,10 +162,6 @@ pub(crate) fn escape_special_characters<'a>(t: &'a str, state: &State<'a>, optio
         Cow::Borrowed(t)
     }
 }
-
-//======================================
-// General-purpose string utilities
-//======================================
 
 pub(crate) fn max_consecutive_chars(text: &str, search: char) -> usize {
     let mut in_search_chars = false;


### PR DESCRIPTION
Stacked PRs:

- [x] Part 1: #98
- [x] Part 2: #100
- [x] Part 3: #101
- [ ] ➡️ Part 4: #103 

----

My impression reading through the code in this project is that top-level statements have gotten a bit intertangled over time; this tries to reorder things to have a clearer flow and structure, grouping related things together.

For example, this moves the recently added Error enum up above all of the API functions, instead of leaving it somewhat arbitrarily nestled between `cmark_resume_with_options()` and `cmark_resume_one_event()`.

No code changes were made to the body of functions or types. This also does not change any of the public APIs, only where code is located.

* Group padded newline logic at top of text_modifications.rs

* Rename `padding_of()` to `list_item_padding_of()`

* Add 'Public API Functions' header in lib.rs

* Consolidate public enum and struct types at the top of lib.rs, instead of leaving them scattered amongst the `cmark*()` public functions.

* Consolidate the two `impl State<'_>` statements

* Move `cmark_resume()`, `cmark()` and `cmark_with_options()` from the bottom of lib.rs up to the top, before the ~600 implementation of `cmark_resume_one_event()` that makes up the bulk of lib.rs