### PR TITLE
refactor: Add `Repeated` utility to simplify writing repeated content (Part 5/X)

### DIFF
--- a/src/text_modifications.rs
+++ b/src/text_modifications.rs
@@ -199,3 +199,22 @@ mod max_consecutive_chars {
         );
     }
 }
+
+//=====================================
+// General-purpose formatting utilities
+//=====================================
+
+/// `Repeated(content, count` formats as `content` repeated `count` times.
+#[derive(Debug)]
+pub(crate) struct Repeated<T>(pub T, pub usize);
+
+impl<T: fmt::Display> fmt::Display for Repeated<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Repeated(content, count) = self;
+
+        for _ in 0..*count {
+            T::fmt(content, f)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Stacked PRs:

*Note: The diff for this PR will include all unmerged prior PRs, making it artificially large until rebased onto main.*

- [x] Part 1: #98
- [x] Part 2: #100
- [x] Part 3: #101
- [x] Part 4: #103 
- [ ] ➡️ Part 5: #104

---

This is a small one, but hopefully improves readability a bit, and helps avoid string allocations.
