### PR TITLE
Superscript and Subscript rendering using symbols

### DIFF
--- a/examples/stupicat.rs
+++ b/examples/stupicat.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use pulldown_cmark::{Options, Parser};
-use pulldown_cmark_to_cmark::{cmark, cmark_resume};
+use pulldown_cmark_to_cmark::{cmark_resume_with_options, cmark_with_options};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::args_os()
@@ -17,16 +17,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = Options::all();
     options.remove(Options::ENABLE_SMART_PUNCTUATION);
 
+    let mut render_options = pulldown_cmark_to_cmark::Options::default();
+    if env::var_os("STUPICAT_SUB_SUPER_SYMBOLIC").is_some() {
+        render_options.use_html_for_super_sub_script = false;
+    }
+
     if event_by_event {
         let mut state = None;
         for event in Parser::new_ext(&md, options) {
-            state = cmark_resume(std::iter::once(event), &mut buf, state.take())?.into();
+            state = cmark_resume_with_options(std::iter::once(event), &mut buf, state.take(), render_options.clone())?
+                .into();
         }
         if let Some(state) = state {
             state.finalize(&mut buf)?;
         }
     } else {
-        cmark(Parser::new_ext(&md, options), &mut buf)?;
+        cmark_with_options(Parser::new_ext(&md, options), &mut buf, render_options)?;
     }
 
     stdout().write_all(buf.as_bytes())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,13 @@ pub struct Options<'a> {
     pub emphasis_token: char,
     /// The string to use for strong emphasis (bold)
     pub strong_token: &'a str,
+    /// Whether or not to use HTML tags `<sup>` and `<sub>`, or the Markdown
+    /// symbols `^` and `~` when rendering superscript and subscript.
+    /// If you use [`ENABLE_SUPERSCRIPT`][`pulldown_cmark::Options::ENABLE_SUPERSCRIPT`] and
+    /// [`ENABLE_SUBSCRIPT`][`pulldown_cmark::Options::ENABLE_SUBSCRIPT`] when parsing, then
+    /// you might need this in order to round-trip markdown byte-for-byte rather than simply
+    /// event-for-event.
+    pub use_html_for_super_sub_script: bool,
 }
 
 const DEFAULT_OPTIONS: Options<'_> = Options {
@@ -268,6 +275,7 @@ const DEFAULT_OPTIONS: Options<'_> = Options {
     increment_ordered_list_bullets: false,
     emphasis_token: '*',
     strong_token: "**",
+    use_html_for_super_sub_script: true,
 };
 
 impl Default for Options<'_> {
@@ -674,8 +682,16 @@ where
                     state.padding.push(every_line_padding.into());
                     Ok(())
                 }
-                Superscript => formatter.write_str("<sup>"),
-                Subscript => formatter.write_str("<sub>"),
+                Superscript => formatter.write_str(if options.use_html_for_super_sub_script {
+                    "<sup>"
+                } else {
+                    "^"
+                }),
+                Subscript => formatter.write_str(if options.use_html_for_super_sub_script {
+                    "<sub>"
+                } else {
+                    "~"
+                }),
             }
         }
         End(tag) => match tag {
@@ -903,8 +919,16 @@ where
                 state.padding.pop();
                 write_padded_newline(formatter, &state)
             }
-            TagEnd::Superscript => formatter.write_str("</sup>"),
-            TagEnd::Subscript => formatter.write_str("</sub>"),
+            TagEnd::Superscript => formatter.write_str(if options.use_html_for_super_sub_script {
+                "</sup>"
+            } else {
+                "^"
+            }),
+            TagEnd::Subscript => formatter.write_str(if options.use_html_for_super_sub_script {
+                "</sub>"
+            } else {
+                "~"
+            }),
         },
         HardBreak => formatter.write_str("  ").and(write_padded_newline(formatter, &state)),
         SoftBreak => write_padded_newline(formatter, &state),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,12 +248,13 @@ pub struct Options<'a> {
     pub emphasis_token: char,
     /// The string to use for strong emphasis (bold)
     pub strong_token: &'a str,
-    /// Whether or not to use HTML tags `<sup>` and `<sub>`, or the Markdown
-    /// symbols `^` and `~` when rendering superscript and subscript.
-    /// If you use [`ENABLE_SUPERSCRIPT`][`pulldown_cmark::Options::ENABLE_SUPERSCRIPT`] and
-    /// [`ENABLE_SUBSCRIPT`][`pulldown_cmark::Options::ENABLE_SUBSCRIPT`] when parsing, then
-    /// you might need this in order to round-trip markdown byte-for-byte rather than simply
-    /// event-for-event.
+    /// If `true` (default) then use HTML tags `<sup>` and `<sub>`.
+    /// If `false`, use the Markdown symbols `^` and `~` instead.
+    ///
+    /// If you use [`ENABLE_SUPERSCRIPT`](pulldown_cmark::Options::ENABLE_SUPERSCRIPT) and
+    /// [`ENABLE_SUBSCRIPT`](pulldown_cmark::Options::ENABLE_SUBSCRIPT) when parsing, then
+    /// you might need this in order to round-trip Markdown byte-for-byte, with knowledge
+    /// of whether the parsed documents use `<sub>`/`<sup>` or `^`/`~` instead.
     pub use_html_for_super_sub_script: bool,
 }
 

--- a/tests/cat.sh
+++ b/tests/cat.sh
@@ -117,3 +117,10 @@ title "stupicat"
     WITH_SNAPSHOT="$snapshot/stupicat-super-sub-script-output" \
     expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/super-sub-script.md 2>/dev/null"
 )
+
+(with "symbolic super and subscript"
+  it "succeeds" && \
+    WITH_SNAPSHOT="$snapshot/stupicat-symbolic-super-sub-script-output" \
+    STUPICAT_SUB_SUPER_SYMBOLIC="1" \
+    expect_run_sh $SUCCESSFULLY "${exe[*]} $fixture/symbolic-super-sub-script.md 2>/dev/null"
+)

--- a/tests/fixtures/snapshots/stupicat-symbolic-super-sub-script-output
+++ b/tests/fixtures/snapshots/stupicat-symbolic-super-sub-script-output
@@ -1,0 +1,5 @@
+this is an example of ^superscript^.
+
+this is an example of ~subscript~.
+
+1^st^ of the month.

--- a/tests/fixtures/symbolic-super-sub-script.md
+++ b/tests/fixtures/symbolic-super-sub-script.md
@@ -1,0 +1,5 @@
+this is an example of ^superscript^.
+
+this is an example of ~subscript~.
+
+1^st^ of the month.


### PR DESCRIPTION
`pulldown-cmark` can parse `^superscript^` and `~subscript~` and in order to be able to roundtrip that kind of thing, I thought it would be good to add an option to permit the use of `^` and `~` rather than `<sup>` and `<sub>`.

This is my first time touching this project so please let me know if I've done anything awful, or if you need me to fix up my commit messages to fit your process more.
